### PR TITLE
fix(account)!: determine physical resource id on create account is complete

### DIFF
--- a/src/account-provider/on-event-handler.lambda.ts
+++ b/src/account-provider/on-event-handler.lambda.ts
@@ -44,23 +44,14 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse | 
     console.log("Creating account: %j", response);
 
     return {
-      PhysicalResourceId: response.CreateAccountStatus?.Id,
       Data: { ...event.ResourceProperties, CreateAccountStatusId: response.CreateAccountStatus?.Id },
     };
-  }
-
-  let data;
-  if (/\d{12}/.test(event.PhysicalResourceId!)) {
-    data = { AccountId: event.PhysicalResourceId };
-  } else {
-    data = { CreateAccountStatusId: event.PhysicalResourceId };
   }
 
   return {
     ...event,
     Data: {
       ...event.ResourceProperties,
-      ...data,
     },
   };
 }

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -160,7 +160,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/2f954ad51f0ef4a510876a85a9248f415309afa2033f345ec83f00e799367a72.json",
+              "/a6f01f3e521db187a185d4d6d598f822de56cb40e909ea1536a3900980270973.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -154,7 +154,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/2f954ad51f0ef4a510876a85a9248f415309afa2033f345ec83f00e799367a72.json",
+              "/a6f01f3e521db187a185d4d6d598f822de56cb40e909ea1536a3900980270973.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -507,7 +507,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/489b78e0eda81d22b8ccb977c4beb25da10900669155c37b4cc0d2786ced6345.json",
+              "/648f2b580c8a9d99de9df3f7bf28499fbe0b8d67ffec9afeaf3425bbf5817d8d.json",
             ],
           ],
         },
@@ -1186,7 +1186,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/61dc08daf079c0366ebead1a1b5ec5296b4e4061bab3da44c56d743afd876ca0.json",
+              "/6abf649770db7f1d42918fb5eb1e749c480868e774c22077f0bd45f4732fa670.json",
             ],
           ],
         },
@@ -1308,7 +1308,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/6b180276ff1ab6979ea335b8d9fecebb395c4515f0d871bf745a093fc7d47d22.json",
+              "/e18cf9697804e854bf4c3c54c1e91c7e95265fb7bb8584a6d8826fb9cd3a09c4.json",
             ],
           ],
         },
@@ -1569,7 +1569,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/6db9381378fdf74eba8c0402d358eefcc8849be19e516a4f0a69761de97e2f16.json",
+              "/4c546c5462dd2678f050985762a7af27d3b2fe4a50bb899060f648cf7485b6bf.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -154,7 +154,7 @@ Object {
               Object {
                 "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "/2f954ad51f0ef4a510876a85a9248f415309afa2033f345ec83f00e799367a72.json",
+              "/a6f01f3e521db187a185d4d6d598f822de56cb40e909ea1536a3900980270973.json",
             ],
           ],
         },

--- a/test/account-provider/is-complete-handler.lambda.test.ts
+++ b/test/account-provider/is-complete-handler.lambda.test.ts
@@ -107,6 +107,7 @@ describe("account-provider.is-complete-handler.lambda", () => {
     sinon.assert.called(describeAccountFake);
     sinon.assert.notCalled(moveAccountFake);
     expect(response.IsComplete).toBeTruthy();
+    expect(response.PhysicalResourceId).toEqual("123456789012");
     expect(response.Data?.AccountId).toEqual("123456789012");
     expect(response.Data?.AccountName).toEqual("test");
   });
@@ -142,7 +143,14 @@ describe("account-provider.is-complete-handler.lambda", () => {
 
   it("Should be moved to parent", async () => {
     // Given
-    const describeCreateAccountStatusFake = sinon.fake.resolves(undefined);
+    const mock: SDK.Organizations.DescribeCreateAccountStatusResponse = {
+      CreateAccountStatus: {
+        Id: "car-exampleaccountcreationrequestid",
+        AccountId: "123456789012",
+        State: "SUCCEEDED",
+      },
+    };
+    const describeCreateAccountStatusFake = sinon.fake.resolves(mock);
     AWS.mock("Organizations", "describeCreateAccountStatus", describeCreateAccountStatusFake);
     const describeAccountResponseMock: SDK.Organizations.DescribeAccountResponse = {
       Account: {
@@ -179,7 +187,7 @@ describe("account-provider.is-complete-handler.lambda", () => {
     const response = await handler(request as IsCompleteRequest);
 
     // Then
-    sinon.assert.notCalled(describeCreateAccountStatusFake);
+    sinon.assert.called(describeCreateAccountStatusFake);
     sinon.assert.called(describeAccountFake);
     sinon.assert.called(listParentsFake);
     sinon.assert.called(moveAccountFake);
@@ -218,7 +226,7 @@ describe("account-provider.is-complete-handler.lambda", () => {
     const request: Partial<IsCompleteRequest> = {
       ...event,
       RequestType: "Delete",
-      PhysicalResourceId: "car-exampleaccountcreationrequestid",
+      PhysicalResourceId: "123456789012",
       Data: {
         AccountId: "123456789012",
       },
@@ -239,6 +247,7 @@ describe("account-provider.is-complete-handler.lambda", () => {
     sinon.assert.called(listParentsFake);
     sinon.assert.called(moveAccountFake);
     expect(response.IsComplete).toBeTruthy();
+    expect(response.PhysicalResourceId).toEqual("123456789012");
     expect(response.Data?.AccountId).toEqual("123456789012");
     expect(response.Data?.AccountName).toEqual("test");
   });

--- a/test/account-provider/on-event-handler.lambda.test.ts
+++ b/test/account-provider/on-event-handler.lambda.test.ts
@@ -60,7 +60,7 @@ describe("account-provider.on-event-handler.lambda", () => {
 
     // Then
     expect(response).not.toBeUndefined();
-    expect(response?.PhysicalResourceId).toEqual("car-exampleaccountcreationrequestid");
+    expect(response?.PhysicalResourceId).toBeUndefined();
     expect(response?.Data?.CreateAccountStatusId).toEqual("car-exampleaccountcreationrequestid");
     sinon.assert.calledOnce(createAccountFake);
   });


### PR DESCRIPTION
Updates to [aws-cdk-lib >= 2.15.0](https://github.com/aws/aws-cdk/releases/tag/v2.15.0)

BREAKING CHANGE:
The account's physical resource id will be the account id. The account id is determined in the is complete handler. If the resource was using the create status request id before, it will trigger a cloudformation lifecycle.

See [AWS CFN - Custom Resources - Remarks](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html#aws-resource-cfn-customresource--remarks)