### PR TITLE
fix: scope of policy attachment and delegated administrator

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,6 @@
+{
+  "context": {
+    "account": "123456789012",
+    "region": "us-east-1"
+  }
+}

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,4 +1,4 @@
-import { Annotations, CustomResource, Names, RemovalPolicy, TagManager, TagType } from "aws-cdk-lib";
+import { Annotations, CustomResource, Names, RemovalPolicy, Stack, TagManager, TagType } from "aws-cdk-lib";
 import { Construct, IConstruct } from "constructs";
 import { pascalCase } from "pascal-case";
 import { AccountProvider } from "./account-provider";
@@ -152,10 +152,14 @@ export class Account extends Construct implements IAccount, ITaggableResource {
    * @param {string} servicePrincipal The supported AWS service that you specify
    */
   public delegateAdministrator(servicePrincipal: string) {
-    const delegatedAdministrator = new DelegatedAdministrator(this, `Delegate${pascalCase(servicePrincipal)}`, {
-      account: this,
-      servicePrincipal: servicePrincipal,
-    });
+    const delegatedAdministrator = new DelegatedAdministrator(
+      Stack.of(this),
+      `Delegate${pascalCase(servicePrincipal)}-${Names.nodeUniqueId(this.node)}`,
+      {
+        account: this,
+        servicePrincipal: servicePrincipal,
+      }
+    );
     delegatedAdministrator.node.addDependency(this.resource);
   }
 
@@ -165,10 +169,14 @@ export class Account extends Construct implements IAccount, ITaggableResource {
    * @see https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies.html
    */
   public attachPolicy(policy: IPolicy) {
-    const policyAttachment = new PolicyAttachment(this, `PolicyAttachment-${Names.nodeUniqueId(policy.node)}`, {
-      target: this,
-      policy: policy,
-    });
+    const policyAttachment = new PolicyAttachment(
+      Stack.of(this),
+      `PolicyAttachment-${Names.nodeUniqueId(this.node)}-${Names.nodeUniqueId(policy.node)}`,
+      {
+        target: this,
+        policy: policy,
+      }
+    );
     policyAttachment.node.addDependency(this.resource, policy);
   }
 }

--- a/src/integ.default.ts
+++ b/src/integ.default.ts
@@ -5,7 +5,7 @@ import { OrganizationalUnit } from "./organizational-unit";
 import { Policy, PolicyType } from "./policy";
 
 const app = new App();
-const stack = new Stack(app);
+const stack = new Stack(app, undefined, { env: { account: "123456789012", region: "us-east-1" } });
 
 // Create an organization
 const organization = new Organization(stack, "Organization", {

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -1,4 +1,4 @@
-import { CustomResource, Names, TagManager, TagType } from "aws-cdk-lib";
+import { CustomResource, Names, Stack, TagManager, TagType } from "aws-cdk-lib";
 import * as aws_iam from "aws-cdk-lib/aws-iam";
 import * as custom_resources from "aws-cdk-lib/custom-resources";
 import { Construct, IConstruct } from "constructs";
@@ -264,10 +264,14 @@ export class Root extends Construct implements IParent, IPolicyAttachmentTarget,
    * @see https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies.html
    */
   public attachPolicy(policy: IPolicy) {
-    const policyAttachment = new PolicyAttachment(this, `PolicyAttachment-${Names.nodeUniqueId(policy.node)}`, {
-      target: this,
-      policy: policy,
-    });
+    const policyAttachment = new PolicyAttachment(
+      Stack.of(this),
+      `PolicyAttachment-${Names.nodeUniqueId(this.node)}-${Names.nodeUniqueId(policy.node)}`,
+      {
+        target: this,
+        policy: policy,
+      }
+    );
     policyAttachment.node.addDependency(this.resource, policy);
   }
 
@@ -277,7 +281,7 @@ export class Root extends Construct implements IParent, IPolicyAttachmentTarget,
    * @see https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_enable-disable.html
    */
   public enablePolicyType(policyType: PolicyType) {
-    const enablePolicyType = new EnablePolicyType(this, `Enable${pascalCase(policyType)}`, {
+    const enablePolicyType = new EnablePolicyType(Stack.of(this), `Enable${pascalCase(policyType)}`, {
       root: this,
       policyType: policyType,
     });

--- a/src/organizational-unit.ts
+++ b/src/organizational-unit.ts
@@ -1,4 +1,4 @@
-import { Annotations, CustomResource, Names, RemovalPolicy, TagManager, TagType } from "aws-cdk-lib";
+import { Annotations, CustomResource, Names, RemovalPolicy, Stack, TagManager, TagType } from "aws-cdk-lib";
 import { Construct, IConstruct } from "constructs";
 import { OrganizationalUnitProvider } from "./organizational-unit-provider/organizational-unit-provider";
 import { IChild, IParent } from "./parent";
@@ -105,10 +105,14 @@ export class OrganizationalUnit extends Construct implements IOrganizationalUnit
    * @see https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies.html
    */
   public attachPolicy(policy: IPolicy) {
-    const policyAttachment = new PolicyAttachment(this, `PolicyAttachment-${Names.nodeUniqueId(policy.node)}`, {
-      target: this,
-      policy: policy,
-    });
+    const policyAttachment = new PolicyAttachment(
+      Stack.of(this),
+      `PolicyAttachment-${Names.nodeUniqueId(this.node)}-${Names.nodeUniqueId(policy.node)}`,
+      {
+        target: this,
+        policy: policy,
+      }
+    );
     policyAttachment.node.addDependency(this.resource, policy);
   }
 }

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -201,19 +199,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/eb001b1a121924fe4f664028b87607a11b9248655f43597828f06fbf3128e899.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
             ],
           ],
         },
@@ -228,19 +218,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/9e5867c9df0902f1f9049e2bbb453c6acc604443472dccdc193c8a38dd48421c.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
             ],
           ],
         },
@@ -255,19 +237,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -203,7 +203,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/599959be26ef78c08cfea5a4bfb104a5f0df2b2d3bf658aaef97a8161c6a2e26.json",
             ],
           ],
         },
@@ -222,7 +222,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1ac657a0bd4c74ac4c09420ac8281aa0b217baccf53830b13813b2f3195a5b82.json",
             ],
           ],
         },
@@ -241,7 +241,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -189,7 +189,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/599959be26ef78c08cfea5a4bfb104a5f0df2b2d3bf658aaef97a8161c6a2e26.json",
             ],
           ],
         },
@@ -208,7 +208,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -187,19 +185,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/eb001b1a121924fe4f664028b87607a11b9248655f43597828f06fbf3128e899.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
             ],
           ],
         },
@@ -214,19 +204,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/dependency-chain.test.ts.snap
+++ b/test/__snapshots__/dependency-chain.test.ts.snap
@@ -1,0 +1,1148 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DependencyChain Should chain accounts with delegated administrator 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "AWS679f53fac002430cb0da5b7982bd22872D164C4C": Object {
+      "DependsOn": Array [
+        "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
+          "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "AdminAccountCreateAccount96C27ABB": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicyCA61EA18",
+        "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResource7C1CC143",
+      ],
+      "Properties": Object {
+        "AccountName": "test1",
+        "Email": "account1@pepperize.com",
+        "IamUserAccessToBilling": "ALLOW",
+        "ImportOnDuplicate": "true",
+        "RemovalPolicy": "retain",
+        "RoleName": "OrganizationAccountAccessRole",
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsAccountProviderNestedStackcdkorganizationsAccountProviderNestedStackResourceA1C2E3D5",
+            "Outputs.cdkorganizationsAccountProviderframeworkonEvent4241E2B3Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_Account",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "AdminAccountTagsTagResource2B03F65D": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicyCA61EA18",
+        "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResource7C1CC143",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "AdminAccountCreateAccount96C27ABB",
+            "AccountId",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DelegateAccountAmazonawsComAdminAccountDelegatedAdministratorCustomResourceCD37BB5F": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "AdminAccountTagsTagResource2B03F65D",
+        "DelegateAccountAmazonawsComAdminAccountDelegatedAdministratorCustomResourceCustomResourcePolicy716955ED",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"registerDelegatedAdministrator\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              ":account.amazonaws.com\\"},\\"parameters\\":{\\"AccountId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\",\\"ServicePrincipal\\":\\"account.amazonaws.com\\"}}",
+            ],
+          ],
+        },
+        "Delete": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"registerDelegatedAdministrator\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"AccountId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\",\\"ServicePrincipal\\":\\"account.amazonaws.com\\"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_DelegatedAdministrator",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DelegateAccountAmazonawsComAdminAccountDelegatedAdministratorCustomResourceCustomResourcePolicy716955ED": Object {
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "AdminAccountTagsTagResource2B03F65D",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:RegisterDelegatedAdministrator",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DelegateAccountAmazonawsComAdminAccountDelegatedAdministratorCustomResourceCustomResourcePolicy716955ED",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "Organization06E16095": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "FeatureSet": "ALL",
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsOrganizationProviderNestedStackcdkorganizationsOrganizationProviderNestedStackResourceE0751832",
+            "Outputs.cdkorganizationsOrganizationProviderframeworkonEvent268B5E2CArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_Organization",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResource29DFBC85": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicy04A5FB0C",
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"enableAWSServiceAccess\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"account.amazonaws.com\\"},\\"parameters\\":{\\"ServicePrincipal\\":\\"account.amazonaws.com\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"disableAWSServiceAccess\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"ServicePrincipal\\":\\"account.amazonaws.com\\"}}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_EnableAwsServiceAccess",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicy04A5FB0C": Object {
+      "DependsOn": Array [
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:EnableAWSServiceAccess",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DisableAWSServiceAccess",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicy04A5FB0C",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResource7C1CC143": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicy04A5FB0C",
+        "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResource29DFBC85",
+        "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicyCA61EA18",
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"enableAWSServiceAccess\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"sso.amazonaws.com\\"},\\"parameters\\":{\\"ServicePrincipal\\":\\"sso.amazonaws.com\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"disableAWSServiceAccess\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"ServicePrincipal\\":\\"sso.amazonaws.com\\"}}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_EnableAwsServiceAccess",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicyCA61EA18": Object {
+      "DependsOn": Array [
+        "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicy04A5FB0C",
+        "OrganizationEnableAccountAmazonawsComEnableAwsServiceAccessCustomResource29DFBC85",
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:EnableAWSServiceAccess",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DisableAWSServiceAccess",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "OrganizationEnableSsoAmazonawsComEnableAwsServiceAccessCustomResourceCustomResourcePolicyCA61EA18",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "OrganizationRootRootCustomResourceBB74F060": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Organization06E16095",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\"}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
+      },
+      "Type": "Custom::Organizations_Root",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E": Object {
+      "DependsOn": Array [
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:ListRoots",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "OrganizationRootTagsTagResourceCBEA7B2F": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Organization06E16095",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "OrganizationRootRootCustomResourceBB74F060",
+            "Roots.0.Id",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "cdkorganizationsAccountProviderNestedStackcdkorganizationsAccountProviderNestedStackResourceA1C2E3D5": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "TemplateURL": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "https://s3.us-east-1.",
+              Object {
+                "Ref": "AWS::URLSuffix",
+              },
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "cdkorganizationsOrganizationProviderNestedStackcdkorganizationsOrganizationProviderNestedStackResourceE0751832": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "TemplateURL": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "https://s3.us-east-1.",
+              Object {
+                "Ref": "AWS::URLSuffix",
+              },
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "TemplateURL": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "https://s3.us-east-1.",
+              Object {
+                "Ref": "AWS::URLSuffix",
+              },
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`DependencyChain Should chain policy attachments 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "AWS679f53fac002430cb0da5b7982bd22872D164C4C": Object {
+      "DependsOn": Array [
+        "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
+          "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "AdminAccountCreateAccount96C27ABB": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "AccountName": "test1",
+        "Email": "account1@pepperize.com",
+        "IamUserAccessToBilling": "ALLOW",
+        "ImportOnDuplicate": "true",
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "OrganizationRootRootCustomResourceBB74F060",
+            "Roots.0.Id",
+          ],
+        },
+        "RemovalPolicy": "retain",
+        "RoleName": "OrganizationAccountAccessRole",
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsAccountProviderNestedStackcdkorganizationsAccountProviderNestedStackResourceA1C2E3D5",
+            "Outputs.cdkorganizationsAccountProviderframeworkonEvent4241E2B3Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_Account",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "AdminAccountTagsTagResource2B03F65D": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "AdminAccountCreateAccount96C27ABB",
+            "AccountId",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Organization06E16095": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "FeatureSet": "ALL",
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsOrganizationProviderNestedStackcdkorganizationsOrganizationProviderNestedStackResourceE0751832",
+            "Outputs.cdkorganizationsOrganizationProviderframeworkonEvent268B5E2CArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_Organization",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationRootRootCustomResourceBB74F060": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Organization06E16095",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\"}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
+      },
+      "Type": "Custom::Organizations_Root",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E": Object {
+      "DependsOn": Array [
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:ListRoots",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "OrganizationRootTagsTagResourceCBEA7B2F": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Organization06E16095",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "OrganizationRootRootCustomResourceBB74F060",
+            "Roots.0.Id",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Policy1PolicyCustomResourceCustomResourcePolicy7BD4545C": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:CreatePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:UpdatePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DeletePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "Policy1PolicyCustomResourceCustomResourcePolicy7BD4545C",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "Policy1PolicyCustomResourceF56F0D55": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Policy1PolicyCustomResourceCustomResourcePolicy7BD4545C",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"createPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"Content\\":\\"{\\\\n\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":{\\\\n\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"s3:*\\\\\\"\\\\n}\\\\n}\\",\\"Name\\":\\"AllowAllS3Actions\\",\\"Type\\":\\"SERVICE_CONTROL_POLICY\\"},\\"outputPaths\\":[\\"Policy.PolicySummary.Id\\"],\\"physicalResourceId\\":{\\"responsePath\\":\\"Policy.PolicySummary.Id\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"deletePolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"PHYSICAL:RESOURCEID:\\"}}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"updatePolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"Content\\":\\"{\\\\n\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":{\\\\n\\\\\\"Effect\\\\\\":\\\\\\"Allow\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"s3:*\\\\\\"\\\\n}\\\\n}\\",\\"Name\\":\\"AllowAllS3Actions\\",\\"PolicyId\\":\\"PHYSICAL:RESOURCEID:\\"},\\"outputPaths\\":[\\"Policy.PolicySummary.Id\\"],\\"physicalResourceId\\":{\\"responsePath\\":\\"Policy.PolicySummary.Id\\"}}",
+      },
+      "Type": "Custom::Organizations_Policy",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Policy1TagsTagResourceB3B4BDA1": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Policy1PolicyCustomResourceCustomResourcePolicy7BD4545C",
+        "Policy1PolicyCustomResourceF56F0D55",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "Policy1PolicyCustomResourceF56F0D55",
+            "Policy.PolicySummary.Id",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Policy2PolicyCustomResourceCustomResourcePolicy0976B915": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:CreatePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:UpdatePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DeletePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "Policy2PolicyCustomResourceCustomResourcePolicy0976B915",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "Policy2PolicyCustomResourceF58BCA47": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Policy2PolicyCustomResourceCustomResourcePolicy0976B915",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"createPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"Content\\":\\"{\\\\n\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":{\\\\n\\\\\\"Effect\\\\\\":\\\\\\"Deny\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"*:*\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Condition\\\\\\":\\\\n{\\\\n\\\\\\"StringNotEquals\\\\\\":{\\\\\\"aws:RequestedRegion\\\\\\":[\\\\\\"us-east-1\\\\\\"]}\\\\n}\\\\n}\\\\n}\\",\\"Name\\":\\"DenyAllNotUsEast1\\",\\"Type\\":\\"SERVICE_CONTROL_POLICY\\"},\\"outputPaths\\":[\\"Policy.PolicySummary.Id\\"],\\"physicalResourceId\\":{\\"responsePath\\":\\"Policy.PolicySummary.Id\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"deletePolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"PHYSICAL:RESOURCEID:\\"}}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"updatePolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"Content\\":\\"{\\\\n\\\\\\"Version\\\\\\":\\\\\\"2012-10-17\\\\\\",\\\\\\"Statement\\\\\\":{\\\\n\\\\\\"Effect\\\\\\":\\\\\\"Deny\\\\\\",\\\\\\"Action\\\\\\":\\\\\\"*:*\\\\\\",\\\\\\"Resource\\\\\\":\\\\\\"*\\\\\\",\\\\\\"Condition\\\\\\":\\\\n{\\\\n\\\\\\"StringNotEquals\\\\\\":{\\\\\\"aws:RequestedRegion\\\\\\":[\\\\\\"us-east-1\\\\\\"]}\\\\n}\\\\n}\\\\n}\\",\\"Name\\":\\"DenyAllNotUsEast1\\",\\"PolicyId\\":\\"PHYSICAL:RESOURCEID:\\"},\\"outputPaths\\":[\\"Policy.PolicySummary.Id\\"],\\"physicalResourceId\\":{\\"responsePath\\":\\"Policy.PolicySummary.Id\\"}}",
+      },
+      "Type": "Custom::Organizations_Policy",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "Policy2TagsTagResource6E81FFB3": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Policy2PolicyCustomResourceCustomResourcePolicy0976B915",
+        "Policy2PolicyCustomResourceF58BCA47",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "Policy2PolicyCustomResourceF58BCA47",
+            "Policy.PolicySummary.Id",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PolicyAttachmentAdminAccountPolicy1CustomResourceCustomResourcePolicy2618855F": Object {
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "AdminAccountTagsTagResource2B03F65D",
+        "Policy1PolicyCustomResourceCustomResourcePolicy7BD4545C",
+        "Policy1PolicyCustomResourceF56F0D55",
+        "Policy1TagsTagResourceB3B4BDA1",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:AttachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DetachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PolicyAttachmentAdminAccountPolicy1CustomResourceCustomResourcePolicy2618855F",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PolicyAttachmentAdminAccountPolicy1CustomResourceEDA19BC8": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "AdminAccountTagsTagResource2B03F65D",
+        "Policy1PolicyCustomResourceCustomResourcePolicy7BD4545C",
+        "Policy1PolicyCustomResourceF56F0D55",
+        "Policy1TagsTagResourceB3B4BDA1",
+        "PolicyAttachmentAdminAccountPolicy1CustomResourceCustomResourcePolicy2618855F",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy1PolicyCustomResourceF56F0D55",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy1PolicyCustomResourceF56F0D55",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "Delete": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy1PolicyCustomResourceF56F0D55",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy1PolicyCustomResourceF56F0D55",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_PolicyAttachment",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PolicyAttachmentAdminAccountPolicy2CustomResource90BD4E0D": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "Policy2PolicyCustomResourceCustomResourcePolicy0976B915",
+        "Policy2PolicyCustomResourceF58BCA47",
+        "Policy2TagsTagResource6E81FFB3",
+        "PolicyAttachmentAdminAccountPolicy1CustomResourceCustomResourcePolicy2618855F",
+        "PolicyAttachmentAdminAccountPolicy1CustomResourceEDA19BC8",
+        "PolicyAttachmentAdminAccountPolicy2CustomResourceCustomResourcePolicy419A0111",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy2PolicyCustomResourceF58BCA47",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy2PolicyCustomResourceF58BCA47",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "Delete": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy2PolicyCustomResourceF58BCA47",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "Policy2PolicyCustomResourceF58BCA47",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "AdminAccountCreateAccount96C27ABB",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_PolicyAttachment",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PolicyAttachmentAdminAccountPolicy2CustomResourceCustomResourcePolicy419A0111": Object {
+      "DependsOn": Array [
+        "AdminAccountCreateAccount96C27ABB",
+        "Policy2PolicyCustomResourceCustomResourcePolicy0976B915",
+        "Policy2PolicyCustomResourceF58BCA47",
+        "Policy2TagsTagResource6E81FFB3",
+        "PolicyAttachmentAdminAccountPolicy1CustomResourceCustomResourcePolicy2618855F",
+        "PolicyAttachmentAdminAccountPolicy1CustomResourceEDA19BC8",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:AttachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DetachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PolicyAttachmentAdminAccountPolicy2CustomResourceCustomResourcePolicy419A0111",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "cdkorganizationsAccountProviderNestedStackcdkorganizationsAccountProviderNestedStackResourceA1C2E3D5": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "TemplateURL": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "https://s3.us-east-1.",
+              Object {
+                "Ref": "AWS::URLSuffix",
+              },
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "cdkorganizationsOrganizationProviderNestedStackcdkorganizationsOrganizationProviderNestedStackResourceE0751832": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "TemplateURL": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "https://s3.us-east-1.",
+              Object {
+                "Ref": "AWS::URLSuffix",
+              },
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "TemplateURL": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "https://s3.us-east-1.",
+              Object {
+                "Ref": "AWS::URLSuffix",
+              },
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/test/__snapshots__/dependency-chain.test.ts.snap
+++ b/test/__snapshots__/dependency-chain.test.ts.snap
@@ -386,7 +386,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/599959be26ef78c08cfea5a4bfb104a5f0df2b2d3bf658aaef97a8161c6a2e26.json",
             ],
           ],
         },
@@ -405,7 +405,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1ac657a0bd4c74ac4c09420ac8281aa0b217baccf53830b13813b2f3195a5b82.json",
             ],
           ],
         },
@@ -424,7 +424,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },
@@ -1070,7 +1070,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/599959be26ef78c08cfea5a4bfb104a5f0df2b2d3bf658aaef97a8161c6a2e26.json",
             ],
           ],
         },
@@ -1089,7 +1089,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1ac657a0bd4c74ac4c09420ac8281aa0b217baccf53830b13813b2f3195a5b82.json",
             ],
           ],
         },
@@ -1108,7 +1108,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/enable-aws-service-access.test.ts.snap
+++ b/test/__snapshots__/enable-aws-service-access.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",

--- a/test/__snapshots__/enable-policy-type.test.ts.snap
+++ b/test/__snapshots__/enable-policy-type.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -234,19 +232,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/9e5867c9df0902f1f9049e2bbb453c6acc604443472dccdc193c8a38dd48421c.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
             ],
           ],
         },
@@ -261,19 +251,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/enable-policy-type.test.ts.snap
+++ b/test/__snapshots__/enable-policy-type.test.ts.snap
@@ -236,7 +236,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1ac657a0bd4c74ac4c09420ac8281aa0b217baccf53830b13813b2f3195a5b82.json",
             ],
           ],
         },
@@ -255,7 +255,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -1671,7 +1671,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/637a44c78d4f61be24a4f4c9362847eb6a8b2fdce3d0a62397c100bf78ffb771.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/fcd1531e7867c29f62f35f2e7a868b654fbd3388d52815b44549394244610a7c.json",
             ],
           ],
         },
@@ -1696,7 +1696,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/79bbda9381357b526ffa5636921ff556ba33742d6e935ecd890b1d09e7f29b1f.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/2c8774ebe3c4ec99a56e3c664f4614380fc34e03154acadd8d89871551ace97e.json",
             ],
           ],
         },
@@ -1721,7 +1721,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/3435a5aeccaf17f67b86f874d895460edc55b2b80a81bd1aef31ece2ef7eb79b.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/c3018da5bb7cb0841d42f9dce1b36d76ddd7134c2e5378879e84d11e52d5b356.json",
             ],
           ],
         },
@@ -1746,7 +1746,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ed4d924b24aa99d1542557f3f0946fed79b353e1f836d3517fe177810d8b60e.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d0a6f787f7773b81956738fdd429b484c0fedefd8ae5808c350c653946bf74b4.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -76,60 +74,11 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ImportedAccountCreateAccount0DDC7950": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "AccountName": "test",
-        "Email": "info+integ-test@pepperize.com",
-        "IamUserAccessToBilling": "ALLOW",
-        "ImportOnDuplicate": "true",
-        "ParentId": Object {
-          "Fn::GetAtt": Array [
-            "OrganizationRootRootCustomResourceBB74F060",
-            "Roots.0.Id",
-          ],
-        },
-        "RemovalPolicy": "retain",
-        "RoleName": "OrganizationAccountAccessRole",
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "cdkorganizationsAccountProviderNestedStackcdkorganizationsAccountProviderNestedStackResourceA1C2E3D5",
-            "Outputs.cdkorganizationsAccountProviderframeworkonEvent4241E2B3Arn",
-          ],
-        },
-      },
-      "Type": "Custom::Organizations_Account",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ImportedAccountDelegateConfigAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicyA6F85B48": Object {
-      "DependsOn": Array [
-        "ImportedAccountCreateAccount0DDC7950",
-      ],
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "organizations:RegisterDelegatedAdministrator",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ImportedAccountDelegateConfigAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicyA6F85B48",
-        "Roles": Array [
-          Object {
-            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "ImportedAccountDelegateConfigAmazonawsComDelegatedAdministratorCustomResourceEA9B3A5B": Object {
+    "DelegateConfigAmazonawsComImportedAccountDelegatedAdministratorCustomResource0A389794": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
+        "DelegateConfigAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicy6144D93D",
         "ImportedAccountCreateAccount0DDC7950",
-        "ImportedAccountDelegateConfigAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicyA6F85B48",
       ],
       "Properties": Object {
         "Create": Object {
@@ -180,11 +129,35 @@ Object {
       "Type": "Custom::Organizations_DelegatedAdministrator",
       "UpdateReplacePolicy": "Delete",
     },
-    "ImportedAccountDelegateServiceAbbreviationAmazonawsComDelegatedAdministratorCustomResource513A981D": Object {
-      "DeletionPolicy": "Delete",
+    "DelegateConfigAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicy6144D93D": Object {
       "DependsOn": Array [
         "ImportedAccountCreateAccount0DDC7950",
-        "ImportedAccountDelegateServiceAbbreviationAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicy46D1A807",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:RegisterDelegatedAdministrator",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DelegateConfigAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicy6144D93D",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DelegateServiceAbbreviationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCF552F1E": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DelegateServiceAbbreviationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicyF6BF55E8",
+        "ImportedAccountCreateAccount0DDC7950",
       ],
       "Properties": Object {
         "Create": Object {
@@ -235,7 +208,7 @@ Object {
       "Type": "Custom::Organizations_DelegatedAdministrator",
       "UpdateReplacePolicy": "Delete",
     },
-    "ImportedAccountDelegateServiceAbbreviationAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicy46D1A807": Object {
+    "DelegateServiceAbbreviationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicyF6BF55E8": Object {
       "DependsOn": Array [
         "ImportedAccountCreateAccount0DDC7950",
       ],
@@ -250,7 +223,7 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "ImportedAccountDelegateServiceAbbreviationAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicy46D1A807",
+        "PolicyName": "DelegateServiceAbbreviationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicyF6BF55E8",
         "Roles": Array [
           Object {
             "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -259,11 +232,11 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ImportedAccountDelegateStacksetsCloudformationAmazonawsComDelegatedAdministratorCustomResource8EC61813": Object {
+    "DelegateStacksetsCloudformationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceA30F5AF0": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
+        "DelegateStacksetsCloudformationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicy36E8971F",
         "ImportedAccountCreateAccount0DDC7950",
-        "ImportedAccountDelegateStacksetsCloudformationAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicy3C86DE9E",
       ],
       "Properties": Object {
         "Create": Object {
@@ -314,7 +287,7 @@ Object {
       "Type": "Custom::Organizations_DelegatedAdministrator",
       "UpdateReplacePolicy": "Delete",
     },
-    "ImportedAccountDelegateStacksetsCloudformationAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicy3C86DE9E": Object {
+    "DelegateStacksetsCloudformationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicy36E8971F": Object {
       "DependsOn": Array [
         "ImportedAccountCreateAccount0DDC7950",
       ],
@@ -329,7 +302,7 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "ImportedAccountDelegateStacksetsCloudformationAmazonawsComDelegatedAdministratorCustomResourceCustomResourcePolicy3C86DE9E",
+        "PolicyName": "DelegateStacksetsCloudformationAmazonawsComImportedAccountDelegatedAdministratorCustomResourceCustomResourcePolicy36E8971F",
         "Roles": Array [
           Object {
             "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -338,30 +311,28 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ImportedAccountPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicyEF2394C4": Object {
+    "EnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy9EF8F17B": Object {
       "DependsOn": Array [
-        "ImportedAccountCreateAccount0DDC7950",
-        "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
-        "S3PolicyPolicyCustomResource0D921FA4",
-        "S3PolicyTagsTagResource12DC413E",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
       ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
-              "Action": "organizations:AttachPolicy",
+              "Action": "organizations:EnablePolicyType",
               "Effect": "Allow",
               "Resource": "*",
             },
             Object {
-              "Action": "organizations:DetachPolicy",
+              "Action": "organizations:DisablePolicyType",
               "Effect": "Allow",
               "Resource": "*",
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "ImportedAccountPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicyEF2394C4",
+        "PolicyName": "EnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy9EF8F17B",
         "Roles": Array [
           Object {
             "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -370,49 +341,33 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ImportedAccountPolicyAttachmentS3PolicyCustomResourceFB92BF90": Object {
+    "EnableServiceControlPolicyEnablePolicyTypeCustomResourceD40D4ABC": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "ImportedAccountCreateAccount0DDC7950",
-        "ImportedAccountPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicyEF2394C4",
-        "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
-        "S3PolicyPolicyCustomResource0D921FA4",
-        "S3PolicyTagsTagResource12DC413E",
+        "EnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy9EF8F17B",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
       ],
       "Properties": Object {
         "Create": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"enablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "S3PolicyPolicyCustomResource0D921FA4",
-                  "Policy.PolicySummary.Id",
+                  "OrganizationRootRootCustomResourceBB74F060",
+                  "Roots.0.Id",
                 ],
               },
-              "\\",\\"TargetId\\":\\"",
+              ":SERVICE_CONTROL_POLICY\\"},\\"parameters\\":{\\"RootId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
+                  "OrganizationRootRootCustomResourceBB74F060",
+                  "Roots.0.Id",
                 ],
               },
-              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "S3PolicyPolicyCustomResource0D921FA4",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              ":",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
-                ],
-              },
-              "\\"}}",
+              "\\",\\"PolicyType\\":\\"SERVICE_CONTROL_POLICY\\"}}",
             ],
           ],
         },
@@ -420,35 +375,14 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"disablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"RootId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "S3PolicyPolicyCustomResource0D921FA4",
-                  "Policy.PolicySummary.Id",
+                  "OrganizationRootRootCustomResourceBB74F060",
+                  "Roots.0.Id",
                 ],
               },
-              "\\",\\"TargetId\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
-                ],
-              },
-              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "S3PolicyPolicyCustomResource0D921FA4",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              ":",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
-                ],
-              },
-              "\\"}}",
+              "\\",\\"PolicyType\\":\\"SERVICE_CONTROL_POLICY\\"}}",
             ],
           ],
         },
@@ -460,52 +394,36 @@ Object {
           ],
         },
       },
-      "Type": "Custom::Organizations_PolicyAttachment",
+      "Type": "Custom::Organizations_EnablePolicyType",
       "UpdateReplacePolicy": "Delete",
     },
-    "ImportedAccountPolicyAttachmentTagPolicyCustomResource2004384F": Object {
+    "EnableTagPolicyEnablePolicyTypeCustomResource07E29550": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "ImportedAccountCreateAccount0DDC7950",
-        "ImportedAccountPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicyE523677D",
-        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
-        "TagPolicyPolicyCustomResource70E64110",
-        "TagPolicyTagsTagResource71A94A6C",
+        "EnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicyBC501C01",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
       ],
       "Properties": Object {
         "Create": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"enablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
+                  "OrganizationRootRootCustomResourceBB74F060",
+                  "Roots.0.Id",
                 ],
               },
-              "\\",\\"TargetId\\":\\"",
+              ":TAG_POLICY\\"},\\"parameters\\":{\\"RootId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
+                  "OrganizationRootRootCustomResourceBB74F060",
+                  "Roots.0.Id",
                 ],
               },
-              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              ":",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
-                ],
-              },
-              "\\"}}",
+              "\\",\\"PolicyType\\":\\"TAG_POLICY\\"}}",
             ],
           ],
         },
@@ -513,35 +431,14 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"disablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"RootId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
+                  "OrganizationRootRootCustomResourceBB74F060",
+                  "Roots.0.Id",
                 ],
               },
-              "\\",\\"TargetId\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
-                ],
-              },
-              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              ":",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ImportedAccountCreateAccount0DDC7950",
-                  "AccountId",
-                ],
-              },
-              "\\"}}",
+              "\\",\\"PolicyType\\":\\"TAG_POLICY\\"}}",
             ],
           ],
         },
@@ -553,33 +450,31 @@ Object {
           ],
         },
       },
-      "Type": "Custom::Organizations_PolicyAttachment",
+      "Type": "Custom::Organizations_EnablePolicyType",
       "UpdateReplacePolicy": "Delete",
     },
-    "ImportedAccountPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicyE523677D": Object {
+    "EnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicyBC501C01": Object {
       "DependsOn": Array [
-        "ImportedAccountCreateAccount0DDC7950",
-        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
-        "TagPolicyPolicyCustomResource70E64110",
-        "TagPolicyTagsTagResource71A94A6C",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
       ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
-              "Action": "organizations:AttachPolicy",
+              "Action": "organizations:EnablePolicyType",
               "Effect": "Allow",
               "Resource": "*",
             },
             Object {
-              "Action": "organizations:DetachPolicy",
+              "Action": "organizations:DisablePolicyType",
               "Effect": "Allow",
               "Resource": "*",
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "ImportedAccountPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicyE523677D",
+        "PolicyName": "EnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicyBC501C01",
         "Roles": Array [
           Object {
             "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -587,6 +482,31 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "ImportedAccountCreateAccount0DDC7950": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "AccountName": "test",
+        "Email": "info+integ-test@pepperize.com",
+        "IamUserAccessToBilling": "ALLOW",
+        "ImportOnDuplicate": "true",
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "OrganizationRootRootCustomResourceBB74F060",
+            "Roots.0.Id",
+          ],
+        },
+        "RemovalPolicy": "retain",
+        "RoleName": "OrganizationAccountAccessRole",
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsAccountProviderNestedStackcdkorganizationsAccountProviderNestedStackResourceA1C2E3D5",
+            "Outputs.cdkorganizationsAccountProviderframeworkonEvent4241E2B3Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_Account",
+      "UpdateReplacePolicy": "Delete",
     },
     "ImportedAccountTagsTagResourceEAA2977A": Object {
       "DeletionPolicy": "Delete",
@@ -777,34 +697,124 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceBFCAC35E": Object {
+    "OrganizationRootRootCustomResourceBB74F060": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "Organization06E16095",
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE",
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+      ],
+      "Properties": Object {
+        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
+        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\"}",
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
+      },
+      "Type": "Custom::Organizations_Root",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E": Object {
+      "DependsOn": Array [
+        "Organization06E16095",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:ListRoots",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "OrganizationRootTagsTagResourceCBEA7B2F": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "Organization06E16095",
         "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
         "OrganizationRootRootCustomResourceBB74F060",
+      ],
+      "Properties": Object {
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "OrganizationRootRootCustomResourceBB74F060",
+            "Roots.0.Id",
+          ],
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
+            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "tagKey",
+            "Value": "tagValue",
+          },
+        ],
+      },
+      "Type": "Custom::Organizations_TagResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PolicyAttachmentImportedAccountS3PolicyCustomResource6DEE3EC0": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "ImportedAccountCreateAccount0DDC7950",
+        "PolicyAttachmentImportedAccountS3PolicyCustomResourceCustomResourcePolicy259549DD",
+        "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
+        "S3PolicyPolicyCustomResource0D921FA4",
+        "S3PolicyTagsTagResource12DC413E",
       ],
       "Properties": Object {
         "Create": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"enablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "OrganizationRootRootCustomResourceBB74F060",
-                  "Roots.0.Id",
+                  "S3PolicyPolicyCustomResource0D921FA4",
+                  "Policy.PolicySummary.Id",
                 ],
               },
-              ":SERVICE_CONTROL_POLICY\\"},\\"parameters\\":{\\"RootId\\":\\"",
+              "\\",\\"TargetId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "OrganizationRootRootCustomResourceBB74F060",
-                  "Roots.0.Id",
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
                 ],
               },
-              "\\",\\"PolicyType\\":\\"SERVICE_CONTROL_POLICY\\"}}",
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "S3PolicyPolicyCustomResource0D921FA4",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
             ],
           ],
         },
@@ -812,14 +822,35 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"disablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"RootId\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "OrganizationRootRootCustomResourceBB74F060",
-                  "Roots.0.Id",
+                  "S3PolicyPolicyCustomResource0D921FA4",
+                  "Policy.PolicySummary.Id",
                 ],
               },
-              "\\",\\"PolicyType\\":\\"SERVICE_CONTROL_POLICY\\"}}",
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "S3PolicyPolicyCustomResource0D921FA4",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
             ],
           ],
         },
@@ -831,32 +862,33 @@ Object {
           ],
         },
       },
-      "Type": "Custom::Organizations_EnablePolicyType",
+      "Type": "Custom::Organizations_PolicyAttachment",
       "UpdateReplacePolicy": "Delete",
     },
-    "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE": Object {
+    "PolicyAttachmentImportedAccountS3PolicyCustomResourceCustomResourcePolicy259549DD": Object {
       "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
+        "ImportedAccountCreateAccount0DDC7950",
+        "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
+        "S3PolicyPolicyCustomResource0D921FA4",
+        "S3PolicyTagsTagResource12DC413E",
       ],
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
             Object {
-              "Action": "organizations:EnablePolicyType",
+              "Action": "organizations:AttachPolicy",
               "Effect": "Allow",
               "Resource": "*",
             },
             Object {
-              "Action": "organizations:DisablePolicyType",
+              "Action": "organizations:DetachPolicy",
               "Effect": "Allow",
               "Resource": "*",
             },
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE",
+        "PolicyName": "PolicyAttachmentImportedAccountS3PolicyCustomResourceCustomResourcePolicy259549DD",
         "Roles": Array [
           Object {
             "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -865,65 +897,49 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6": Object {
-      "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
-      ],
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "organizations:EnablePolicyType",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "organizations:DisablePolicyType",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6",
-        "Roles": Array [
-          Object {
-            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceED8FC3FD": Object {
+    "PolicyAttachmentImportedAccountTagPolicyCustomResource5A336197": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
+        "ImportedAccountCreateAccount0DDC7950",
+        "PolicyAttachmentImportedAccountTagPolicyCustomResourceCustomResourcePolicy472CADFE",
+        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
+        "TagPolicyPolicyCustomResource70E64110",
+        "TagPolicyTagsTagResource71A94A6C",
       ],
       "Properties": Object {
         "Create": Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"enablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"id\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "OrganizationRootRootCustomResourceBB74F060",
-                  "Roots.0.Id",
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
                 ],
               },
-              ":TAG_POLICY\\"},\\"parameters\\":{\\"RootId\\":\\"",
+              "\\",\\"TargetId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "OrganizationRootRootCustomResourceBB74F060",
-                  "Roots.0.Id",
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
                 ],
               },
-              "\\",\\"PolicyType\\":\\"TAG_POLICY\\"}}",
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
             ],
           ],
         },
@@ -931,14 +947,35 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"disablePolicyType\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"RootId\\":\\"",
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "OrganizationRootRootCustomResourceBB74F060",
-                  "Roots.0.Id",
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
                 ],
               },
-              "\\",\\"PolicyType\\":\\"TAG_POLICY\\"}}",
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ImportedAccountCreateAccount0DDC7950",
+                  "AccountId",
+                ],
+              },
+              "\\"}}",
             ],
           ],
         },
@@ -950,16 +987,80 @@ Object {
           ],
         },
       },
-      "Type": "Custom::Organizations_EnablePolicyType",
+      "Type": "Custom::Organizations_PolicyAttachment",
       "UpdateReplacePolicy": "Delete",
     },
-    "OrganizationRootPolicyAttachmentS3PolicyCustomResource239E79D1": Object {
-      "DeletionPolicy": "Delete",
+    "PolicyAttachmentImportedAccountTagPolicyCustomResourceCustomResourcePolicy472CADFE": Object {
       "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B",
+        "ImportedAccountCreateAccount0DDC7950",
+        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
+        "TagPolicyPolicyCustomResource70E64110",
+        "TagPolicyTagsTagResource71A94A6C",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:AttachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DetachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PolicyAttachmentImportedAccountTagPolicyCustomResourceCustomResourcePolicy472CADFE",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PolicyAttachmentOrganizationRootAC58C4A1S3PolicyCustomResourceCustomResourcePolicy203724F7": Object {
+      "DependsOn": Array [
         "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
         "OrganizationRootRootCustomResourceBB74F060",
+        "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
+        "S3PolicyPolicyCustomResource0D921FA4",
+        "S3PolicyTagsTagResource12DC413E",
+      ],
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "organizations:AttachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "organizations:DetachPolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PolicyAttachmentOrganizationRootAC58C4A1S3PolicyCustomResourceCustomResourcePolicy203724F7",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PolicyAttachmentOrganizationRootAC58C4A1S3PolicyCustomResourceF14B69B5": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
+        "OrganizationRootRootCustomResourceBB74F060",
+        "PolicyAttachmentOrganizationRootAC58C4A1S3PolicyCustomResourceCustomResourcePolicy203724F7",
         "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
         "S3PolicyPolicyCustomResource0D921FA4",
         "S3PolicyTagsTagResource12DC413E",
@@ -1048,14 +1149,105 @@ Object {
       "Type": "Custom::Organizations_PolicyAttachment",
       "UpdateReplacePolicy": "Delete",
     },
-    "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B": Object {
+    "PolicyAttachmentProjectsOUTagPolicyCustomResource58DC6C44": Object {
+      "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
-        "S3PolicyPolicyCustomResourceCustomResourcePolicyCA33F036",
-        "S3PolicyPolicyCustomResource0D921FA4",
-        "S3PolicyTagsTagResource12DC413E",
+        "PolicyAttachmentProjectsOUTagPolicyCustomResourceCustomResourcePolicyE8B00F61",
+        "ProjectsOUOrganizationProvider5CA5D400",
+        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
+        "TagPolicyPolicyCustomResource70E64110",
+        "TagPolicyTagsTagResource71A94A6C",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ProjectsOUOrganizationProvider5CA5D400",
+                  "Id",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ProjectsOUOrganizationProvider5CA5D400",
+                  "Id",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "Delete": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              "\\",\\"TargetId\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ProjectsOUOrganizationProvider5CA5D400",
+                  "Id",
+                ],
+              },
+              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TagPolicyPolicyCustomResource70E64110",
+                  "Policy.PolicySummary.Id",
+                ],
+              },
+              ":",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ProjectsOUOrganizationProvider5CA5D400",
+                  "Id",
+                ],
+              },
+              "\\"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": false,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::Organizations_PolicyAttachment",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PolicyAttachmentProjectsOUTagPolicyCustomResourceCustomResourcePolicyE8B00F61": Object {
+      "DependsOn": Array [
+        "ProjectsOUOrganizationProvider5CA5D400",
+        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
+        "TagPolicyPolicyCustomResource70E64110",
+        "TagPolicyTagsTagResource71A94A6C",
       ],
       "Properties": Object {
         "PolicyDocument": Object {
@@ -1073,7 +1265,7 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B",
+        "PolicyName": "PolicyAttachmentProjectsOUTagPolicyCustomResourceCustomResourcePolicyE8B00F61",
         "Roles": Array [
           Object {
             "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
@@ -1081,81 +1273,6 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "OrganizationRootRootCustomResourceBB74F060": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-      ],
-      "Properties": Object {
-        "Create": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
-        "Delete": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\"}",
-        "InstallLatestAwsSdk": false,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-            "Arn",
-          ],
-        },
-        "Update": "{\\"service\\":\\"Organizations\\",\\"action\\":\\"listRoots\\",\\"region\\":\\"us-east-1\\",\\"physicalResourceId\\":{\\"responsePath\\":\\"Roots.0.Id\\"}}",
-      },
-      "Type": "Custom::Organizations_Root",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E": Object {
-      "DependsOn": Array [
-        "Organization06E16095",
-      ],
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "organizations:ListRoots",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "Roles": Array [
-          Object {
-            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "OrganizationRootTagsTagResourceCBEA7B2F": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "Organization06E16095",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
-      ],
-      "Properties": Object {
-        "ResourceId": Object {
-          "Fn::GetAtt": Array [
-            "OrganizationRootRootCustomResourceBB74F060",
-            "Roots.0.Id",
-          ],
-        },
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "cdkorganizationsTagResourceProviderNestedStackcdkorganizationsTagResourceProviderNestedStackResourceA7B8DF96",
-            "Outputs.cdkorganizationsTagResourceProviderframeworkonEventDD009DFBArn",
-          ],
-        },
-        "Tags": Array [
-          Object {
-            "Key": "tagKey",
-            "Value": "tagValue",
-          },
-        ],
-      },
-      "Type": "Custom::Organizations_TagResource",
-      "UpdateReplacePolicy": "Delete",
     },
     "Project1AccountCreateAccount8A604AF1": Object {
       "DeletionPolicy": "Delete",
@@ -1267,8 +1384,6 @@ Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "ProjectsOUOrganizationProvider5CA5D400",
-        "ProjectsOUPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicy4E70640C",
-        "ProjectsOUPolicyAttachmentTagPolicyCustomResourceC7563B04",
         "ProjectsOUTagsTagResource5FC759B6",
       ],
       "Properties": Object {
@@ -1296,8 +1411,6 @@ Object {
       "DependsOn": Array [
         "Project2OUOrganizationProviderA322B887",
         "ProjectsOUOrganizationProvider5CA5D400",
-        "ProjectsOUPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicy4E70640C",
-        "ProjectsOUPolicyAttachmentTagPolicyCustomResourceC7563B04",
         "ProjectsOUTagsTagResource5FC759B6",
       ],
       "Properties": Object {
@@ -1326,12 +1439,6 @@ Object {
     "ProjectsOUOrganizationProvider5CA5D400": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE",
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceBFCAC35E",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceED8FC3FD",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResource239E79D1",
         "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
         "OrganizationRootRootCustomResourceBB74F060",
         "OrganizationRootTagsTagResourceCBEA7B2F",
@@ -1356,158 +1463,9 @@ Object {
       "Type": "Custom::Organizations_OrganizationalUnitProvider",
       "UpdateReplacePolicy": "Delete",
     },
-    "ProjectsOUPolicyAttachmentTagPolicyCustomResourceC7563B04": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE",
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceBFCAC35E",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceED8FC3FD",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResource239E79D1",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
-        "OrganizationRootTagsTagResourceCBEA7B2F",
-        "ProjectsOUOrganizationProvider5CA5D400",
-        "ProjectsOUPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicy4E70640C",
-        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
-        "TagPolicyPolicyCustomResource70E64110",
-        "TagPolicyTagsTagResource71A94A6C",
-      ],
-      "Properties": Object {
-        "Create": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"attachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              "\\",\\"TargetId\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ProjectsOUOrganizationProvider5CA5D400",
-                  "Id",
-                ],
-              },
-              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              ":",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ProjectsOUOrganizationProvider5CA5D400",
-                  "Id",
-                ],
-              },
-              "\\"}}",
-            ],
-          ],
-        },
-        "Delete": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "{\\"service\\":\\"Organizations\\",\\"action\\":\\"detachPolicy\\",\\"region\\":\\"us-east-1\\",\\"parameters\\":{\\"PolicyId\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              "\\",\\"TargetId\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ProjectsOUOrganizationProvider5CA5D400",
-                  "Id",
-                ],
-              },
-              "\\"},\\"physicalResourceId\\":{\\"id\\":\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "TagPolicyPolicyCustomResource70E64110",
-                  "Policy.PolicySummary.Id",
-                ],
-              },
-              ":",
-              Object {
-                "Fn::GetAtt": Array [
-                  "ProjectsOUOrganizationProvider5CA5D400",
-                  "Id",
-                ],
-              },
-              "\\"}}",
-            ],
-          ],
-        },
-        "InstallLatestAwsSdk": false,
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::Organizations_PolicyAttachment",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ProjectsOUPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicy4E70640C": Object {
-      "DependsOn": Array [
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE",
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceBFCAC35E",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceED8FC3FD",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResource239E79D1",
-        "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
-        "OrganizationRootRootCustomResourceBB74F060",
-        "OrganizationRootTagsTagResourceCBEA7B2F",
-        "ProjectsOUOrganizationProvider5CA5D400",
-        "TagPolicyPolicyCustomResourceCustomResourcePolicyBC4C6C1B",
-        "TagPolicyPolicyCustomResource70E64110",
-        "TagPolicyTagsTagResource71A94A6C",
-      ],
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "organizations:AttachPolicy",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "organizations:DetachPolicy",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ProjectsOUPolicyAttachmentTagPolicyCustomResourceCustomResourcePolicy4E70640C",
-        "Roles": Array [
-          Object {
-            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "ProjectsOUTagsTagResource5FC759B6": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy811B6EDE",
-        "OrganizationRootEnableServiceControlPolicyEnablePolicyTypeCustomResourceBFCAC35E",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceCustomResourcePolicy163ADBD6",
-        "OrganizationRootEnableTagPolicyEnablePolicyTypeCustomResourceED8FC3FD",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResourceCustomResourcePolicy598F850B",
-        "OrganizationRootPolicyAttachmentS3PolicyCustomResource239E79D1",
         "OrganizationRootRootCustomResourceCustomResourcePolicyB45F831E",
         "OrganizationRootRootCustomResourceBB74F060",
         "OrganizationRootTagsTagResourceCBEA7B2F",
@@ -1709,19 +1667,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/6ddd4a130b12ae44cdb54ad112574afae3786c67b9180b801785aed77484bfde.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/637a44c78d4f61be24a4f4c9362847eb6a8b2fdce3d0a62397c100bf78ffb771.json",
             ],
           ],
         },
@@ -1742,19 +1692,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/095df59f930335262d950333a7fd1850adb4eb5cfe8c70bffd07766230d4cf7f.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/79bbda9381357b526ffa5636921ff556ba33742d6e935ecd890b1d09e7f29b1f.json",
             ],
           ],
         },
@@ -1775,19 +1717,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/66edaf523ddc3bf9726af6143330f4e69646ea88784958a72abf0bb45957bd1d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/3435a5aeccaf17f67b86f874d895460edc55b2b80a81bd1aef31ece2ef7eb79b.json",
             ],
           ],
         },
@@ -1808,19 +1742,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/99db6fc4ecef170e5b790e4def48bbfa3dcc5227fba2073d48def72470fb8974.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ed4d924b24aa99d1542557f3f0946fed79b353e1f836d3517fe177810d8b60e.json",
             ],
           ],
         },

--- a/test/__snapshots__/organization.test.ts.snap
+++ b/test/__snapshots__/organization.test.ts.snap
@@ -156,7 +156,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1ac657a0bd4c74ac4c09420ac8281aa0b217baccf53830b13813b2f3195a5b82.json",
             ],
           ],
         },
@@ -175,7 +175,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/organization.test.ts.snap
+++ b/test/__snapshots__/organization.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -154,19 +152,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/9e5867c9df0902f1f9049e2bbb453c6acc604443472dccdc193c8a38dd48421c.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
             ],
           ],
         },
@@ -181,19 +171,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/organizational-unit.test.ts.snap
+++ b/test/__snapshots__/organizational-unit.test.ts.snap
@@ -208,7 +208,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1ac657a0bd4c74ac4c09420ac8281aa0b217baccf53830b13813b2f3195a5b82.json",
             ],
           ],
         },
@@ -227,7 +227,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/fe940c497105534021c412644d66852d2637aaf0451e620408a05415d85e760c.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0368f2f4832ec56f39234dd140ead8e0142eb5cabedad5dd70990ef6b2ea67ac.json",
             ],
           ],
         },
@@ -246,7 +246,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/organizational-unit.test.ts.snap
+++ b/test/__snapshots__/organizational-unit.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -206,19 +204,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/9e5867c9df0902f1f9049e2bbb453c6acc604443472dccdc193c8a38dd48421c.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/db8db456faaf56fef49bd2206b8fbed08b94514b66674cd3369b7e02ea020aa7.json",
             ],
           ],
         },
@@ -233,19 +223,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/34e37bdb342c20f27bb85e24b7f269bb6d7295ae3ba72cb4afc29145d592534d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/fe940c497105534021c412644d66852d2637aaf0451e620408a05415d85e760c.json",
             ],
           ],
         },
@@ -260,19 +242,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -315,7 +315,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/599959be26ef78c08cfea5a4bfb104a5f0df2b2d3bf658aaef97a8161c6a2e26.json",
             ],
           ],
         },
@@ -334,7 +334,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -313,19 +311,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/eb001b1a121924fe4f664028b87607a11b9248655f43597828f06fbf3128e899.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0ab478630037911e90cf38d5239a14d119ca68243e3fad359bf9f7e2569d7189.json",
             ],
           ],
         },
@@ -340,19 +330,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy.test.ts.snap
+++ b/test/__snapshots__/policy.test.ts.snap
@@ -147,7 +147,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/26fc56a5cb0de19f68b9a49334ee38d45c31529bb272cf5e5f0cc10aaca81ccb.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy.test.ts.snap
+++ b/test/__snapshots__/policy.test.ts.snap
@@ -16,9 +16,7 @@ Object {
       ],
       "Properties": Object {
         "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
+          "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
           "S3Key": "6dbd112fe448437b3438da4382c72fccbb7d2ee1543db222620d7447fffebc50.zip",
         },
         "Handler": "index.handler",
@@ -145,19 +143,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/c9777b5cddb2b81f47ba1db7d8d9b7ec7bab7f3521696d65138bb452525a6a04.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d5495ccfde7e91ca12ce7c018d2623625fb6f4e4d25d9a125a52a32289c5d773.json",
             ],
           ],
         },

--- a/test/__snapshots__/tag-resource.test.ts.snap
+++ b/test/__snapshots__/tag-resource.test.ts.snap
@@ -37,19 +37,11 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "https://s3.",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              ".",
+              "https://s3.us-east-1.",
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/",
-              Object {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "/63c2891b8ac0c5867f7576640bfacc1eea6351cf93153a1d9738e3d9804b8d73.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/678c87d558345426c04dcd9e390c66750004536f1870535737e3f33e872eef8b.json",
             ],
           ],
         },

--- a/test/__snapshots__/tag-resource.test.ts.snap
+++ b/test/__snapshots__/tag-resource.test.ts.snap
@@ -41,7 +41,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/678c87d558345426c04dcd9e390c66750004536f1870535737e3f33e872eef8b.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/39bd444dbaa8a6f9ecd5709871c7f41b4db71b81d9fd15b2fe9b6905c36792b0.json",
             ],
           ],
         },

--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -5,7 +5,7 @@ import { Account, Organization } from "../src";
 describe("Account", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
     const organization = new Organization(stack, "Organization", {});
 
     // When

--- a/test/delegated-administrator.test.ts
+++ b/test/delegated-administrator.test.ts
@@ -5,7 +5,7 @@ import { Account, DelegatedAdministrator } from "../src";
 describe("DelegatedAdministrator", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
     const account = new Account(stack, "Account", {
       accountName: "TestAccount",
       email: "info@pepperize.com",

--- a/test/enable-aws-service-access.test.ts
+++ b/test/enable-aws-service-access.test.ts
@@ -5,7 +5,7 @@ import { EnableAwsServiceAccess } from "../src";
 describe("EnableAwsServiceAccess", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
 
     // When
     new EnableAwsServiceAccess(stack, "EnableAwsServiceAccess", {

--- a/test/enable-policy-type.test.ts
+++ b/test/enable-policy-type.test.ts
@@ -5,7 +5,7 @@ import { EnablePolicyType, FeatureSet, Organization, PolicyType } from "../src";
 describe("EnablePolicyType", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
     const organization = new Organization(stack, "Organization", {
       featureSet: FeatureSet.ALL,
     });

--- a/test/organization.test.ts
+++ b/test/organization.test.ts
@@ -6,7 +6,7 @@ import { FeatureSet, Organization, PolicyType } from "../src";
 describe("Organization", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
 
     // When
     new Organization(stack, "Organization", {

--- a/test/organizational-unit.test.ts
+++ b/test/organizational-unit.test.ts
@@ -5,7 +5,7 @@ import { Organization, OrganizationalUnit } from "../src";
 describe("OrganizationalUnit", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
     const organization = new Organization(stack, "Organization", {});
 
     // When

--- a/test/policy-attachment.test.ts
+++ b/test/policy-attachment.test.ts
@@ -5,7 +5,7 @@ import { Account, Policy, PolicyAttachment, PolicyType } from "../src";
 describe("PolicyAttachment", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
     const account = new Account(stack, "Account", {
       accountName: "Test Account",
       email: "info@pepperize.com",

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -5,7 +5,7 @@ import { Policy, PolicyType } from "../src";
 describe("Policy", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
 
     // When
     new Policy(stack, "Policy", {

--- a/test/tag-resource.test.ts
+++ b/test/tag-resource.test.ts
@@ -5,7 +5,7 @@ import { TagResource } from "../src";
 describe("TagResource", () => {
   it("Should match snapshot", () => {
     // Given
-    const stack = new Stack();
+    const stack = new Stack(undefined, undefined, { env: { account: "123456789012", region: "us-east-1" } });
     const tags = new TagManager(TagType.KEY_VALUE, "Custom::Organizations_TagResource");
 
     // When


### PR DESCRIPTION
avoid circular dependencies, when chaining parent-child and sibling dependencies. If policy attachments are of same dependency group it will result in circular references.

Relates to https://github.com/pepperize/cdk-organizations/issues/447