### PR TITLE
chore(release): include chore type messages

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -31,7 +31,8 @@
         "OUTFILE": "package.json",
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
-        "RELEASETAG": "dist/releasetag.txt"
+        "RELEASETAG": "dist/releasetag.txt",
+        "VERSIONRCOPTIONS": "{\"types\":[{\"type\":\"chore\",\"section\":\"Chore\",\"hidden\":false}]}"
       },
       "steps": [
         {
@@ -398,7 +399,8 @@
         "OUTFILE": "package.json",
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
-        "RELEASETAG": "dist/releasetag.txt"
+        "RELEASETAG": "dist/releasetag.txt",
+        "VERSIONRCOPTIONS": "{\"types\":[{\"type\":\"chore\",\"section\":\"Chore\",\"hidden\":false}]}"
       },
       "steps": [
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -40,6 +40,10 @@ const project = new AwsCdkConstructLibrary({
     "sinon",
   ],
 
+  versionrcOptions: {
+    types: [{ type: "chore", section: "Chore", hidden: false }],
+  },
+
   defaultReleaseBranch: "main",
   releaseToNpm: true,
   npmAccess: javascript.NpmAccess.PUBLIC,


### PR DESCRIPTION
Includes chore type messages into conventional changelog

See https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types

Fixes https://github.com/pepperize/cdk-organizations/issues/651

