### PR TITLE
feat(DelegatedAdministrator): added region name to resource logical name, fixes #1004

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -159,7 +159,9 @@ export class Account extends Construct implements IAccount, ITaggableResource {
   public delegateAdministrator(servicePrincipal: string, region?: string) {
     const delegatedAdministrator = new DelegatedAdministrator(
       this.scope,
-      `Delegate${pascalCase(servicePrincipal)}-${Names.nodeUniqueId(this.node)}`,
+      `Delegate${pascalCase(servicePrincipal)}${
+        region && region !== "us-east-1" ? `-${region}` : ""
+      }-${Names.nodeUniqueId(this.node)}`,
       {
         account: this,
         servicePrincipal: servicePrincipal,

--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -37,4 +37,22 @@ describe("Account", () => {
     const template = Template.fromStack(stack);
     template.resourceCountIs("Custom::Organizations_DelegatedAdministrator", 1);
   });
+
+  it("Should have delegated region administrator", () => {
+    // Given
+    const stack = new Stack();
+    const organization = new Organization(stack, "Organization", {});
+    const account = new Account(stack, "Account", {
+      email: "info@pepperize.com",
+      accountName: "test",
+      parent: organization.root,
+    });
+
+    // When
+    account.delegateAdministrator("service-abbreviation.amazonaws.com", "eu-west-1");
+
+    // Then
+    const template = Template.fromStack(stack);
+    template.resourceCountIs("Custom::Organizations_DelegatedAdministrator", 1);
+  });
 });


### PR DESCRIPTION
#1004 
Adding the region to all new delegation resources is risky as it could cause resources to be replaced. So I'm trying to make it behave in a way users expect it to behave. Still, if someone has created a delegation to a non-us-east-1 region, that resource would get replaced with this implementation.