### PR TITLE
feat: Add aws-cn support

### DIFF
--- a/API.md
+++ b/API.md
@@ -401,7 +401,8 @@ AWS Organizations has some limitations:
 
 > AWS Organizations is a global service with service endpoints in `us-east-1`, `us-gov-west-1` and `cn-northwest-1`. Read also
 > [Endpoint to call When using the AWS CLI or the AWS SDK](https://docs.aws.amazon.com/organizations/latest/APIReference/Welcome.html).
-> Currently all custom resources of this library are hard set to use `us-east-1`.
+> Currently all custom resources of this library defaults to use `us-east-1`, but it can be configured to use `cn-northwest-1`
+> with the environment variable `CDK_AWS_PARTITION` set to `aws-cn`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ AWS Organizations has some limitations:
 
 > AWS Organizations is a global service with service endpoints in `us-east-1`, `us-gov-west-1` and `cn-northwest-1`. Read also
 > [Endpoint to call When using the AWS CLI or the AWS SDK](https://docs.aws.amazon.com/organizations/latest/APIReference/Welcome.html).
-> Currently all custom resources of this library are hard set to use `us-east-1`.
+> Currently all custom resources of this library defaults to use `us-east-1`, but it can be configured to use `cn-northwest-1`
+> with the environment variable `CDK_AWS_PARTITION` set to `aws-cn`.
 
 ## Example
 

--- a/src/account-provider/account-provider.ts
+++ b/src/account-provider/account-provider.ts
@@ -46,7 +46,12 @@ export class AccountProvider extends NestedStack {
   constructor(scope: Construct, id: string, props: AccountProviderProps) {
     super(scope, id, props);
 
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
     this.onEventHandler = new OnEventHandlerFunction(this, "OnEventHandlerFunction", {
+      environment: {
+        ORGANIZATIONS_ENDPOINT_REGION: organizationsRegion,
+      },
       timeout: Duration.minutes(10),
       initialPolicy: [
         new PolicyStatement({
@@ -57,6 +62,9 @@ export class AccountProvider extends NestedStack {
     });
 
     this.isCompleteHandler = new IsCompleteHandlerFunction(this, "IsCompleteHandlerFunction", {
+      environment: {
+        ORGANIZATIONS_ENDPOINT_REGION: organizationsRegion,
+      },
       timeout: Duration.minutes(1),
       initialPolicy: [
         new PolicyStatement({

--- a/src/account-provider/is-complete-handler.lambda.ts
+++ b/src/account-provider/is-complete-handler.lambda.ts
@@ -6,6 +6,7 @@ import * as AWS from "aws-sdk";
 import { Organizations } from "aws-sdk";
 
 let organizationsClient: AWS.Organizations;
+const organizationsRegion = process.env.ORGANIZATIONS_ENDPOINT_REGION ?? "us-east-1";
 
 /**
  * The isComplete handler is repeatedly invoked checking CreateAccountStatus until SUCCEEDED or FAILED.
@@ -15,7 +16,7 @@ export async function handler(event: IsCompleteRequest): Promise<IsCompleteRespo
   console.log(`Request of type ${event.RequestType} received`);
 
   if (!organizationsClient) {
-    organizationsClient = new AWS.Organizations({ region: "us-east-1" });
+    organizationsClient = new AWS.Organizations({ region: organizationsRegion });
   }
 
   console.log("Payload: %j", event);

--- a/src/account-provider/on-event-handler.lambda.ts
+++ b/src/account-provider/on-event-handler.lambda.ts
@@ -2,6 +2,7 @@ import { CdkCustomResourceEvent as OnEventRequest, CdkCustomResourceResponse as 
 import { Organizations } from "aws-sdk";
 
 let organizationsClient: Organizations;
+const organizationsRegion = process.env.ORGANIZATIONS_ENDPOINT_REGION ?? "us-east-1";
 
 /**
  * The onEvent handler is invoked whenever a resource lifecycle event for an Account occurs
@@ -12,7 +13,7 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse> {
   console.log(`Request of type ${event.RequestType} received`);
 
   if (!organizationsClient) {
-    organizationsClient = new Organizations({ region: "us-east-1" });
+    organizationsClient = new Organizations({ region: organizationsRegion });
   }
 
   console.log("Payload: %j", event);

--- a/src/account.ts
+++ b/src/account.ts
@@ -157,10 +157,12 @@ export class Account extends Construct implements IAccount, ITaggableResource {
    * @param {string} region The region to delegate in
    */
   public delegateAdministrator(servicePrincipal: string, region?: string) {
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
     const delegatedAdministrator = new DelegatedAdministrator(
       this.scope,
       `Delegate${pascalCase(servicePrincipal)}${
-        region && region !== "us-east-1" ? `-${region}` : ""
+        region && region !== organizationsRegion ? `-${region}` : ""
       }-${Names.nodeUniqueId(this.node)}`,
       {
         account: this,

--- a/src/delegated-administrator.ts
+++ b/src/delegated-administrator.ts
@@ -29,13 +29,14 @@ export class DelegatedAdministrator extends Construct {
     super(scope, id);
 
     const { account, servicePrincipal, region } = props;
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
 
     new AwsCustomResource(this, "DelegatedAdministratorCustomResource", {
       resourceType: "Custom::Organizations_DelegatedAdministrator",
       onCreate: {
         service: "Organizations",
         action: "registerDelegatedAdministrator", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#registerDelegatedAdministrator-property
-        region: region ?? "us-east-1",
+        region: region ?? organizationsRegion,
         physicalResourceId: PhysicalResourceId.of(`${account.accountId}:${servicePrincipal}`),
         parameters: {
           AccountId: account.accountId,
@@ -46,7 +47,7 @@ export class DelegatedAdministrator extends Construct {
       onDelete: {
         service: "Organizations",
         action: "deregisterDelegatedAdministrator", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#deregisterDelegatedAdministrator-property
-        region: region ?? "us-east-1",
+        region: region ?? organizationsRegion,
         parameters: {
           AccountId: account.accountId,
           ServicePrincipal: servicePrincipal,

--- a/src/enable-aws-service-access.ts
+++ b/src/enable-aws-service-access.ts
@@ -20,13 +20,14 @@ export class EnableAwsServiceAccess extends Construct {
     super(scope, id);
 
     const { servicePrincipal } = props;
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
 
     new AwsCustomResource(this, "EnableAwsServiceAccessCustomResource", {
       resourceType: "Custom::Organizations_EnableAwsServiceAccess",
       onCreate: {
         service: "Organizations",
         action: "enableAWSServiceAccess", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#enableAWSServiceAccess-property
-        region: "us-east-1",
+        region: organizationsRegion,
         physicalResourceId: PhysicalResourceId.of(`${servicePrincipal}`),
         parameters: {
           ServicePrincipal: servicePrincipal,
@@ -35,7 +36,7 @@ export class EnableAwsServiceAccess extends Construct {
       onDelete: {
         service: "Organizations",
         action: "disableAWSServiceAccess", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#disableAWSServiceAccess-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           ServicePrincipal: servicePrincipal,
         },

--- a/src/enable-policy-type.ts
+++ b/src/enable-policy-type.ts
@@ -18,13 +18,14 @@ export class EnablePolicyType extends Construct {
     super(scope, id);
 
     const { root, policyType } = props;
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
 
     new AwsCustomResource(this, "EnablePolicyTypeCustomResource", {
       resourceType: "Custom::Organizations_EnablePolicyType",
       onCreate: {
         service: "Organizations",
         action: "enablePolicyType", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#enablePolicyType-property
-        region: "us-east-1",
+        region: organizationsRegion,
         physicalResourceId: PhysicalResourceId.of(`${root.rootId}:${policyType}`),
         parameters: {
           RootId: root.rootId,
@@ -35,7 +36,7 @@ export class EnablePolicyType extends Construct {
       onDelete: {
         service: "Organizations",
         action: "disablePolicyType", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#disablePolicyType-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           RootId: root.rootId,
           PolicyType: policyType,

--- a/src/organization-provider/on-event-handler.lambda.ts
+++ b/src/organization-provider/on-event-handler.lambda.ts
@@ -2,6 +2,7 @@ import { CdkCustomResourceEvent as OnEventRequest, CdkCustomResourceResponse as 
 import { AWSError, Organizations } from "aws-sdk";
 
 let organizationsClient: Organizations;
+const organizationsRegion = process.env.ORGANIZATIONS_ENDPOINT_REGION ?? "us-east-1";
 
 /**
  * The onEvent handler is invoked whenever a resource lifecycle event for an organization occurs
@@ -12,7 +13,7 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse> {
   console.log(`Request of type ${event.RequestType} received`);
 
   if (!organizationsClient) {
-    organizationsClient = new Organizations({ region: "us-east-1" });
+    organizationsClient = new Organizations({ region: organizationsRegion });
   }
 
   console.log("Payload: %j", event);

--- a/src/organization-provider/organization-provider.ts
+++ b/src/organization-provider/organization-provider.ts
@@ -1,4 +1,4 @@
-import { Duration, NestedStack, NestedStackProps, Stack } from "aws-cdk-lib";
+import { Aws, Duration, NestedStack, NestedStackProps, Stack } from "aws-cdk-lib";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Function } from "aws-cdk-lib/aws-lambda";
 import { Provider } from "aws-cdk-lib/custom-resources";
@@ -54,7 +54,7 @@ export class OrganizationProvider extends NestedStack {
         // permit the creation of service-linked role https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_org_create.html#create-org
         new PolicyStatement({
           actions: ["iam:CreateServiceLinkedRole"],
-          resources: ["arn:aws:iam::*:role/*"],
+          resources: [`arn:${Aws.PARTITION}:iam::*:role/*`],
         }),
       ],
     });

--- a/src/organization-provider/organization-provider.ts
+++ b/src/organization-provider/organization-provider.ts
@@ -44,7 +44,12 @@ export class OrganizationProvider extends NestedStack {
   constructor(scope: Construct, id: string, props: OrganizationProviderProps) {
     super(scope, id, props);
 
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
     this.onEventHandler = new OnEventHandlerFunction(this, "OnEventHandlerFunction", {
+      environment: {
+        ORGANIZATIONS_ENDPOINT_REGION: organizationsRegion,
+      },
       timeout: Duration.minutes(10),
       initialPolicy: [
         new PolicyStatement({

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -98,19 +98,21 @@ export class Organization extends Construct implements IOrganization {
       public constructor() {
         super(scope, id);
 
+        const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
         const resource = new custom_resources.AwsCustomResource(scope, "CustomResource", {
           resourceType: "Custom::Organizations_ImportOrganization",
           onCreate: {
             service: "Organizations",
             action: "describeOrganization", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#describeOrganization-property
-            region: "us-east-1",
+            region: organizationsRegion,
             parameters: {},
             physicalResourceId: custom_resources.PhysicalResourceId.fromResponse("Organization.Id"),
           },
           onUpdate: {
             service: "Organizations",
             action: "describeOrganization", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#describeOrganization-property
-            region: "us-east-1",
+            region: organizationsRegion,
             parameters: {},
             physicalResourceId: custom_resources.PhysicalResourceId.fromResponse("Organization.Id"),
           },
@@ -227,24 +229,26 @@ export class Root extends Construct implements IParent, IPolicyAttachmentTarget,
     super(scope, id);
     this.scope = scope;
 
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
     this.resource = new custom_resources.AwsCustomResource(this, "RootCustomResource", {
       resourceType: "Custom::Organizations_Root",
       onCreate: {
         service: "Organizations",
         action: "listRoots", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#listRoots-property
-        region: "us-east-1",
+        region: organizationsRegion,
         physicalResourceId: custom_resources.PhysicalResourceId.fromResponse("Roots.0.Id"),
       },
       onUpdate: {
         service: "Organizations",
         action: "listRoots", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#listRoots-property
-        region: "us-east-1",
+        region: organizationsRegion,
         physicalResourceId: custom_resources.PhysicalResourceId.fromResponse("Roots.0.Id"),
       },
       onDelete: {
         service: "Organizations",
         action: "listRoots", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#listRoots-property
-        region: "us-east-1",
+        region: organizationsRegion,
       },
       installLatestAwsSdk: false,
       policy: custom_resources.AwsCustomResourcePolicy.fromSdkCalls({

--- a/src/organizational-unit-provider/on-event-handler.lambda.ts
+++ b/src/organizational-unit-provider/on-event-handler.lambda.ts
@@ -2,6 +2,7 @@ import { CdkCustomResourceEvent as OnEventRequest, CdkCustomResourceResponse as 
 import { AWSError, Organizations } from "aws-sdk";
 
 let organizationsClient: Organizations;
+const organizationsRegion = process.env.ORGANIZATIONS_ENDPOINT_REGION ?? "us-east-1";
 
 /**
  * The onEvent handler is invoked whenever a resource lifecycle event for an organizational unit occurs
@@ -12,7 +13,7 @@ export const handler = async (event: OnEventRequest): Promise<OnEventResponse> =
   console.log(`Request of type ${event.RequestType} received`);
 
   if (!organizationsClient) {
-    organizationsClient = new Organizations({ region: "us-east-1" });
+    organizationsClient = new Organizations({ region: organizationsRegion });
   }
 
   console.log("Payload: %j", event);

--- a/src/organizational-unit-provider/organizational-unit-provider.ts
+++ b/src/organizational-unit-provider/organizational-unit-provider.ts
@@ -46,7 +46,12 @@ export class OrganizationalUnitProvider extends NestedStack {
   constructor(scope: Construct, id: string, props: OrganizationalUnitProviderProps) {
     super(scope, id, props);
 
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
     this.onEventHandler = new OnEventHandlerFunction(this, "OnEventHandlerFunction", {
+      environment: {
+        ORGANIZATIONS_ENDPOINT_REGION: organizationsRegion,
+      },
       timeout: Duration.minutes(10),
       initialPolicy: [
         new PolicyStatement({

--- a/src/parent.ts
+++ b/src/parent.ts
@@ -21,12 +21,13 @@ export abstract class ParentBase extends Construct implements IParent {
     super(scope, id);
 
     const { childId } = props;
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
 
     const parent = new AwsCustomResource(this, "ListParentsCustomResource", {
       onCreate: {
         service: "Organizations",
         action: "listParents", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#listParents-property
-        region: "us-east-1",
+        region: organizationsRegion,
         physicalResourceId: PhysicalResourceId.fromResponse("Parents.0.Id"),
         parameters: {
           ChildId: childId,
@@ -35,7 +36,7 @@ export abstract class ParentBase extends Construct implements IParent {
       onUpdate: {
         service: "Organizations",
         action: "listParents", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#listParents-property
-        region: "us-east-1",
+        region: organizationsRegion,
         physicalResourceId: PhysicalResourceId.fromResponse("Parents.0.Id"),
         parameters: {
           ChildId: childId,
@@ -44,7 +45,7 @@ export abstract class ParentBase extends Construct implements IParent {
       onDelete: {
         service: "Organizations",
         action: "listParents", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#listParents-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           ChildId: childId,
         },

--- a/src/policy-attachment.ts
+++ b/src/policy-attachment.ts
@@ -24,13 +24,14 @@ export class PolicyAttachment extends Construct {
     super(scope, id);
 
     const { target, policy } = props;
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
 
     new AwsCustomResource(this, "CustomResource", {
       resourceType: "Custom::Organizations_PolicyAttachment",
       onCreate: {
         service: "Organizations",
         action: "attachPolicy", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#attachPolicy-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           PolicyId: policy.policyId,
           TargetId: target.identifier(),
@@ -40,7 +41,7 @@ export class PolicyAttachment extends Construct {
       onDelete: {
         service: "Organizations",
         action: "detachPolicy", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#detachPolicy-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           PolicyId: policy.policyId,
           TargetId: target.identifier(),

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -80,6 +80,7 @@ export class Policy extends Construct implements IPolicy, ITaggableResource {
     super(scope, id);
 
     const { content, description, policyName, policyType } = props;
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
 
     if (!Validators.of().policyContent(content)) {
       Annotations.of(this).addError(
@@ -92,7 +93,7 @@ export class Policy extends Construct implements IPolicy, ITaggableResource {
       onCreate: {
         service: "Organizations",
         action: "createPolicy", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#createPolicy-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           Content: content,
           Description: description,
@@ -105,7 +106,7 @@ export class Policy extends Construct implements IPolicy, ITaggableResource {
       onUpdate: {
         service: "Organizations",
         action: "updatePolicy", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#updatePolicy-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           Content: content,
           Description: description,
@@ -118,7 +119,7 @@ export class Policy extends Construct implements IPolicy, ITaggableResource {
       onDelete: {
         service: "Organizations",
         action: "deletePolicy", // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Organizations.html#deletePolicy-property
-        region: "us-east-1",
+        region: organizationsRegion,
         parameters: {
           PolicyId: new PhysicalResourceIdReference(),
         },

--- a/src/tag-resource-provider/on-event-handler.lambda.ts
+++ b/src/tag-resource-provider/on-event-handler.lambda.ts
@@ -2,6 +2,7 @@ import { CdkCustomResourceEvent as OnEventRequest, CdkCustomResourceResponse as 
 import { Organizations } from "aws-sdk";
 
 let organizationsClient: Organizations;
+const organizationsRegion = process.env.ORGANIZATIONS_ENDPOINT_REGION ?? "us-east-1";
 
 /**
  * The onEvent handler is invoked whenever a resource lifecycle event for a TagResource occurs
@@ -12,7 +13,7 @@ export async function handler(event: OnEventRequest): Promise<OnEventResponse> {
   console.log(`Request of type ${event.RequestType} received`);
 
   if (!organizationsClient) {
-    organizationsClient = new Organizations({ region: "us-east-1" });
+    organizationsClient = new Organizations({ region: organizationsRegion });
   }
 
   console.log("Payload: %j", event);

--- a/src/tag-resource-provider/tag-resource-provider.ts
+++ b/src/tag-resource-provider/tag-resource-provider.ts
@@ -41,7 +41,12 @@ export class TagResourceProvider extends NestedStack {
   constructor(scope: Construct, id: string, props: TagResourceProviderProps) {
     super(scope, id, props);
 
+    const organizationsRegion = process.env.CDK_AWS_PARTITION === "aws-cn" ? "cn-northwest-1" : "us-east-1";
+
     this.onEventHandler = new OnEventHandlerFunction(this, "OnEventHandlerFunction", {
+      environment: {
+        ORGANIZATIONS_ENDPOINT_REGION: organizationsRegion,
+      },
       timeout: Duration.minutes(10),
       initialPolicy: [
         new PolicyStatement({

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -203,7 +203,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0414e993a8284a9c16b9356010ed65eb3d31e649edca57eca96e5246806466fe.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0cc90bb0fc3b992e0224b6b81177a8826e7a465c95ce9681f403296f5b49e507.json",
             ],
           ],
         },
@@ -222,7 +222,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/14c7d41da181ad055e65f5e49dd615bca9e6070b5161de8bc8bc12358782688d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/081779f83ae90f16185e8186b37859f4be0b92d2906da5bd684c925f95793777.json",
             ],
           ],
         },
@@ -241,7 +241,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -194,7 +194,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0414e993a8284a9c16b9356010ed65eb3d31e649edca57eca96e5246806466fe.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0cc90bb0fc3b992e0224b6b81177a8826e7a465c95ce9681f403296f5b49e507.json",
             ],
           ],
         },
@@ -213,7 +213,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/dependency-chain.test.ts.snap
+++ b/test/__snapshots__/dependency-chain.test.ts.snap
@@ -391,7 +391,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0414e993a8284a9c16b9356010ed65eb3d31e649edca57eca96e5246806466fe.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0cc90bb0fc3b992e0224b6b81177a8826e7a465c95ce9681f403296f5b49e507.json",
             ],
           ],
         },
@@ -410,7 +410,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/14c7d41da181ad055e65f5e49dd615bca9e6070b5161de8bc8bc12358782688d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/081779f83ae90f16185e8186b37859f4be0b92d2906da5bd684c925f95793777.json",
             ],
           ],
         },
@@ -429,7 +429,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },
@@ -1075,7 +1075,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0414e993a8284a9c16b9356010ed65eb3d31e649edca57eca96e5246806466fe.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0cc90bb0fc3b992e0224b6b81177a8826e7a465c95ce9681f403296f5b49e507.json",
             ],
           ],
         },
@@ -1094,7 +1094,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/14c7d41da181ad055e65f5e49dd615bca9e6070b5161de8bc8bc12358782688d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/081779f83ae90f16185e8186b37859f4be0b92d2906da5bd684c925f95793777.json",
             ],
           ],
         },
@@ -1113,7 +1113,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/enable-policy-type.test.ts.snap
+++ b/test/__snapshots__/enable-policy-type.test.ts.snap
@@ -236,7 +236,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/14c7d41da181ad055e65f5e49dd615bca9e6070b5161de8bc8bc12358782688d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/081779f83ae90f16185e8186b37859f4be0b92d2906da5bd684c925f95793777.json",
             ],
           ],
         },
@@ -255,7 +255,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -1754,7 +1754,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/41a988d44fdb71cc66ce306b31227b2858c4b64025b808655d56292330c53eb2.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/8bc1457fb00913e10d3e9b99fbab9fd076cb0ec99e36d5853b541f5e07a34e33.json",
             ],
           ],
         },
@@ -1779,7 +1779,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/51cb175091e01ce3aa40d0b1c8580449cc170e7037e13def430c3c8c2c859009.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/514e759489978d90644a95333547f267889c62b513683adf5f32d59f37b7b759.json",
             ],
           ],
         },
@@ -1804,7 +1804,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/e1763ce8f01d452663034c697c50011f2c7d11cd50932c9f7a49024ba461ed14.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/baaaef717dc878cce9ed14ea8c28ad090f31281da9a95a43cfdb8ffb164dea17.json",
             ],
           ],
         },
@@ -1829,7 +1829,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/8b9a51d34aab09fce70e8429d28fc23096f5c1f682ddb092fbda2dc1c0f9ee26.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/7631703402eef0cbf8c0672fc8c5bfd2ae024e25eebf1f63d2b9835e985abb3b.json",
             ],
           ],
         },

--- a/test/__snapshots__/organization.test.ts.snap
+++ b/test/__snapshots__/organization.test.ts.snap
@@ -156,7 +156,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/14c7d41da181ad055e65f5e49dd615bca9e6070b5161de8bc8bc12358782688d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/081779f83ae90f16185e8186b37859f4be0b92d2906da5bd684c925f95793777.json",
             ],
           ],
         },
@@ -175,7 +175,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/organizational-unit.test.ts.snap
+++ b/test/__snapshots__/organizational-unit.test.ts.snap
@@ -208,7 +208,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/14c7d41da181ad055e65f5e49dd615bca9e6070b5161de8bc8bc12358782688d.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/081779f83ae90f16185e8186b37859f4be0b92d2906da5bd684c925f95793777.json",
             ],
           ],
         },
@@ -227,7 +227,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/964ca73ed46c8e216f43687a094cee170fa8f3c4e03c7874c22d5ec4bb75a56c.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/a114195d324c9ce92388c0e4a0f038ef2cddf84ed2e8830cdd39d98146064028.json",
             ],
           ],
         },
@@ -246,7 +246,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -315,7 +315,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0414e993a8284a9c16b9356010ed65eb3d31e649edca57eca96e5246806466fe.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0cc90bb0fc3b992e0224b6b81177a8826e7a465c95ce9681f403296f5b49e507.json",
             ],
           ],
         },
@@ -334,7 +334,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy.test.ts.snap
+++ b/test/__snapshots__/policy.test.ts.snap
@@ -147,7 +147,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f346d8c676d92a107f908b9aec4db5be56505a96a53c27a324b2f037d893e037.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/07259dc16b8630a4a30fea02c8e09f9f8c2af2a17ba3e9fe0e44879a45085209.json",
             ],
           ],
         },

--- a/test/__snapshots__/tag-resource.test.ts.snap
+++ b/test/__snapshots__/tag-resource.test.ts.snap
@@ -41,7 +41,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/0dfe3680370839896a7f9dbb17b1cc0d2fe26c18baa67c0e1b888f1531a93197.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/7515ae825cc5fad6a9404191acbaf9bbfe843169d7aee832992218ee63f3822e.json",
             ],
           ],
         },


### PR DESCRIPTION
- Use `AWS::Partition` when creating ARN in IAM policy statement, the current partition will be resolved by CloudFormation during deployment.
- The aws partition is not known in all parts of the CDK application when synthesizing. Adding an option to set the partition in an environment variable, enables e.g. Constructs to take decisions based on that.
- Custom resource lambdas operating AWS Organizations uses the correct endpoint based on the partition information.
- The changes are backwards compatible due to defaulting to `us-east-1` endpoint if the `CDK_AWS_PARTITION` is not set.
- The environment variable has also been introduced in https://github.com/cdklabs/cdk-pipelines-github/pull/895.
- These changes are tested in a CDK project with two applications to deploy to both aws and aws-cn partitions, using shared stacks and other resource implementations.

More comments on each commit.

Fixes #