### PR TITLE
chore: update lambda node runtime to 18.x

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -68,7 +68,7 @@
       "description": "Create a JavaScript bundle from src/account-provider/is-complete-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/account-provider/is-complete-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/account-provider/is-complete-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
+          "exec": "esbuild --bundle src/account-provider/is-complete-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/account-provider/is-complete-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -77,7 +77,7 @@
       "description": "Continuously update the JavaScript bundle from src/account-provider/is-complete-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/account-provider/is-complete-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/account-provider/is-complete-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
+          "exec": "esbuild --bundle src/account-provider/is-complete-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/account-provider/is-complete-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },
@@ -86,7 +86,7 @@
       "description": "Create a JavaScript bundle from src/account-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/account-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/account-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
+          "exec": "esbuild --bundle src/account-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/account-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -95,7 +95,7 @@
       "description": "Continuously update the JavaScript bundle from src/account-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/account-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/account-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
+          "exec": "esbuild --bundle src/account-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/account-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },
@@ -104,7 +104,7 @@
       "description": "Create a JavaScript bundle from src/organization-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/organization-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/organization-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
+          "exec": "esbuild --bundle src/organization-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/organization-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -113,7 +113,7 @@
       "description": "Continuously update the JavaScript bundle from src/organization-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/organization-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/organization-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
+          "exec": "esbuild --bundle src/organization-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/organization-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },
@@ -122,7 +122,7 @@
       "description": "Create a JavaScript bundle from src/organizational-unit-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/organizational-unit-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/organizational-unit-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
+          "exec": "esbuild --bundle src/organizational-unit-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/organizational-unit-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -131,7 +131,7 @@
       "description": "Continuously update the JavaScript bundle from src/organizational-unit-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/organizational-unit-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/organizational-unit-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
+          "exec": "esbuild --bundle src/organizational-unit-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/organizational-unit-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },
@@ -140,7 +140,7 @@
       "description": "Create a JavaScript bundle from src/tag-resource-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/tag-resource-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/tag-resource-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
+          "exec": "esbuild --bundle src/tag-resource-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/tag-resource-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\""
         }
       ]
     },
@@ -149,7 +149,7 @@
       "description": "Continuously update the JavaScript bundle from src/tag-resource-provider/on-event-handler.lambda.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/tag-resource-provider/on-event-handler.lambda.ts --target=\"node16\" --platform=\"node\" --outfile=\"assets/tag-resource-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
+          "exec": "esbuild --bundle src/tag-resource-provider/on-event-handler.lambda.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/tag-resource-provider/on-event-handler.lambda/index.js\" --tsconfig=\"tsconfig.dev.json\" --watch"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -66,7 +66,7 @@ const project = new AwsCdkConstructLibrary({
   gitpod: true,
 
   lambdaOptions: {
-    runtime: awscdk.LambdaRuntime.NODEJS_16_X,
+    runtime: awscdk.LambdaRuntime.NODEJS_18_X,
     bundlingOptions: {
       externals: [],
     },

--- a/src/account-provider/is-complete-handler-function.ts
+++ b/src/account-provider/is-complete-handler-function.ts
@@ -17,7 +17,7 @@ export class IsCompleteHandlerFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/account-provider/is-complete-handler.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/account-provider/is-complete-handler.lambda')),
     });

--- a/src/account-provider/on-event-handler-function.ts
+++ b/src/account-provider/on-event-handler-function.ts
@@ -17,7 +17,7 @@ export class OnEventHandlerFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/account-provider/on-event-handler.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/account-provider/on-event-handler.lambda')),
     });

--- a/src/organization-provider/on-event-handler-function.ts
+++ b/src/organization-provider/on-event-handler-function.ts
@@ -17,7 +17,7 @@ export class OnEventHandlerFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/organization-provider/on-event-handler.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/organization-provider/on-event-handler.lambda')),
     });

--- a/src/organizational-unit-provider/on-event-handler-function.ts
+++ b/src/organizational-unit-provider/on-event-handler-function.ts
@@ -17,7 +17,7 @@ export class OnEventHandlerFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/organizational-unit-provider/on-event-handler.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/organizational-unit-provider/on-event-handler.lambda')),
     });

--- a/src/tag-resource-provider/on-event-handler-function.ts
+++ b/src/tag-resource-provider/on-event-handler-function.ts
@@ -17,7 +17,7 @@ export class OnEventHandlerFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/tag-resource-provider/on-event-handler.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/tag-resource-provider/on-event-handler.lambda')),
     });

--- a/test/__snapshots__/account.test.ts.snap
+++ b/test/__snapshots__/account.test.ts.snap
@@ -203,7 +203,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f4cb8ab286195a297196ddc54dbb2b81b5c6d2e3515b78fe9f43a8f48acebdc4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b59768459b4b82ff7ad52b877782f34263712c178b17460e133bdcf2ade0f0d4.json",
             ],
           ],
         },
@@ -222,7 +222,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c953f2c41a9b592d2e19e057ed9c28f8258c0c38a2a7008334b4e63a263dfaab.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d01d6ecb1914edb7421f53426feee52fb1e5b1bd404c935beb83ac03f8ac97a9.json",
             ],
           ],
         },
@@ -241,7 +241,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/delegated-administrator.test.ts.snap
+++ b/test/__snapshots__/delegated-administrator.test.ts.snap
@@ -194,7 +194,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f4cb8ab286195a297196ddc54dbb2b81b5c6d2e3515b78fe9f43a8f48acebdc4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b59768459b4b82ff7ad52b877782f34263712c178b17460e133bdcf2ade0f0d4.json",
             ],
           ],
         },
@@ -213,7 +213,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/dependency-chain.test.ts.snap
+++ b/test/__snapshots__/dependency-chain.test.ts.snap
@@ -391,7 +391,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f4cb8ab286195a297196ddc54dbb2b81b5c6d2e3515b78fe9f43a8f48acebdc4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b59768459b4b82ff7ad52b877782f34263712c178b17460e133bdcf2ade0f0d4.json",
             ],
           ],
         },
@@ -410,7 +410,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c953f2c41a9b592d2e19e057ed9c28f8258c0c38a2a7008334b4e63a263dfaab.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d01d6ecb1914edb7421f53426feee52fb1e5b1bd404c935beb83ac03f8ac97a9.json",
             ],
           ],
         },
@@ -429,7 +429,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },
@@ -1075,7 +1075,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f4cb8ab286195a297196ddc54dbb2b81b5c6d2e3515b78fe9f43a8f48acebdc4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b59768459b4b82ff7ad52b877782f34263712c178b17460e133bdcf2ade0f0d4.json",
             ],
           ],
         },
@@ -1094,7 +1094,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c953f2c41a9b592d2e19e057ed9c28f8258c0c38a2a7008334b4e63a263dfaab.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d01d6ecb1914edb7421f53426feee52fb1e5b1bd404c935beb83ac03f8ac97a9.json",
             ],
           ],
         },
@@ -1113,7 +1113,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/enable-policy-type.test.ts.snap
+++ b/test/__snapshots__/enable-policy-type.test.ts.snap
@@ -236,7 +236,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c953f2c41a9b592d2e19e057ed9c28f8258c0c38a2a7008334b4e63a263dfaab.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d01d6ecb1914edb7421f53426feee52fb1e5b1bd404c935beb83ac03f8ac97a9.json",
             ],
           ],
         },
@@ -255,7 +255,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/integ.default.test.ts.snap
+++ b/test/__snapshots__/integ.default.test.ts.snap
@@ -1754,7 +1754,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/4f70fa052ca45bdfee410d884d5ac8e0eb0b545b2776248b4882a12d4d00c7ff.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/7547babea2dc0f163521b5d64a72e0e85d00446b5d465dac28f77a87ddc2ded8.json",
             ],
           ],
         },
@@ -1779,7 +1779,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/7e9c9f41d9ba5a841d0a7f241caaea5c3edacae9ee6b65c0f369d44115bd5256.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/1d7508eecb18a768f72b25b4a21ca6a149cd4f02f2666ad252a19508c6b50460.json",
             ],
           ],
         },
@@ -1804,7 +1804,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/24bd38ed1379f9e87ca29b498dc7abb02e77595bde4263f363bb8113a474b570.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/5129121bb2b678948d1e1b457c3ec2a10a823247df86f1ab6e8720f5a82345ed.json",
             ],
           ],
         },
@@ -1829,7 +1829,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/1522beb9b0b932539bf8c1a427166ce97d495323bdf7f1fe41bf74537f1d0ea4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/3a618cb6db850925d3c7f518d3d2b49515b8882dfc8486d8ea17092301e41fa7.json",
             ],
           ],
         },

--- a/test/__snapshots__/organization.test.ts.snap
+++ b/test/__snapshots__/organization.test.ts.snap
@@ -156,7 +156,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c953f2c41a9b592d2e19e057ed9c28f8258c0c38a2a7008334b4e63a263dfaab.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d01d6ecb1914edb7421f53426feee52fb1e5b1bd404c935beb83ac03f8ac97a9.json",
             ],
           ],
         },
@@ -175,7 +175,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/organizational-unit.test.ts.snap
+++ b/test/__snapshots__/organizational-unit.test.ts.snap
@@ -208,7 +208,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/c953f2c41a9b592d2e19e057ed9c28f8258c0c38a2a7008334b4e63a263dfaab.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/d01d6ecb1914edb7421f53426feee52fb1e5b1bd404c935beb83ac03f8ac97a9.json",
             ],
           ],
         },
@@ -227,7 +227,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/08529d1810ede697c3861975f193bfe6569627e007b68d366ed6c2fceffa82f8.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/88526d5d019927c33dcfcd4e67ccfdce9f7abb3e50d1b0dcdedac18be3317a5c.json",
             ],
           ],
         },
@@ -246,7 +246,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy-attachment.test.ts.snap
+++ b/test/__snapshots__/policy-attachment.test.ts.snap
@@ -315,7 +315,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/f4cb8ab286195a297196ddc54dbb2b81b5c6d2e3515b78fe9f43a8f48acebdc4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b59768459b4b82ff7ad52b877782f34263712c178b17460e133bdcf2ade0f0d4.json",
             ],
           ],
         },
@@ -334,7 +334,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/policy.test.ts.snap
+++ b/test/__snapshots__/policy.test.ts.snap
@@ -147,7 +147,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/40e8cad2bd1bb5c0be3a4375af732d095035c00871cfb3cf8b1b27d17f4085d4.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/0f21bc31dd8b74ee8b3ce422998bcf7862d43e82fda954994a563e4d9dc2d783.json",
             ],
           ],
         },

--- a/test/__snapshots__/tag-resource.test.ts.snap
+++ b/test/__snapshots__/tag-resource.test.ts.snap
@@ -41,7 +41,7 @@ Object {
               Object {
                 "Ref": "AWS::URLSuffix",
               },
-              "/cdk-hnb659fds-assets-123456789012-us-east-1/935cc4f577c5c3d3a9368c5523c124ee08fa71bc478e301ca18c757b4acd8620.json",
+              "/cdk-hnb659fds-assets-123456789012-us-east-1/b91b826233cb240a8c7b7c2f192db1641384aaa9914a7feecf03869e282b3259.json",
             ],
           ],
         },


### PR DESCRIPTION
Update the Lambda Node.js runtime to 18.x since 16.x is going to be deprecated as of Jun 12, 2024[^1].

This is the most minimal change without upgrading the version of projen itself. Ideally we would want this to move directly to Node.js 20 as well as upgrade all of AWS CDK, SDK and projen to a recent release.

1. See: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported